### PR TITLE
Add keyboard turning support and display minimap overlay

### DIFF
--- a/src/hud.ts
+++ b/src/hud.ts
@@ -1,5 +1,72 @@
 import { config } from './config';
-import type { HUDMessage, PlayerState, Settings, WeaponDefinition } from './types';
+import type {
+  HUDMessage,
+  PlayerState,
+  Settings,
+  WeaponDefinition,
+  LevelDefinition,
+  SpriteRenderable
+} from './types';
+
+function renderMinimap(
+  ctx: CanvasRenderingContext2D,
+  canvas: HTMLCanvasElement,
+  level: LevelDefinition,
+  player: PlayerState,
+  sprites: SpriteRenderable[],
+  settings: Settings
+) {
+  const size = 180;
+  const padding = 24;
+  const tileWidth = size / level.width;
+  const tileHeight = size / level.height;
+  const originX = canvas.width - padding - size;
+  const originY = padding;
+
+  ctx.save();
+  ctx.globalAlpha = Math.min(1, Math.max(0.35, settings.uiOpacity + 0.2));
+  ctx.fillStyle = 'rgba(8, 6, 18, 0.9)';
+  ctx.fillRect(originX - 6, originY - 6, size + 12, size + 12);
+  ctx.strokeStyle = 'rgba(255, 255, 255, 0.25)';
+  ctx.lineWidth = 2;
+  ctx.strokeRect(originX - 6, originY - 6, size + 12, size + 12);
+  ctx.fillStyle = 'rgba(12, 10, 26, 0.9)';
+  ctx.fillRect(originX, originY, size, size);
+
+  ctx.globalAlpha = 1;
+  ctx.fillStyle = '#2d3359';
+  for (let y = 0; y < level.height; y++) {
+    for (let x = 0; x < level.width; x++) {
+      const tile = level.tiles[y * level.width + x];
+      if (tile <= 0) continue;
+      ctx.fillRect(originX + x * tileWidth, originY + y * tileHeight, tileWidth, tileHeight);
+    }
+  }
+
+  for (const sprite of sprites) {
+    const spriteX = originX + sprite.position.x * tileWidth;
+    const spriteY = originY + sprite.position.y * tileHeight;
+    ctx.fillStyle = sprite.type === 'enemy' ? '#ff6b6b' : '#f2c94c';
+    ctx.beginPath();
+    ctx.arc(spriteX, spriteY, sprite.type === 'enemy' ? 3 : 2, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  const playerX = originX + player.position.x * tileWidth;
+  const playerY = originY + player.position.y * tileHeight;
+  ctx.fillStyle = '#ffffff';
+  ctx.beginPath();
+  ctx.arc(playerX, playerY, 4, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.strokeStyle = '#ffffff';
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(playerX, playerY);
+  ctx.lineTo(playerX + player.direction.x * 14, playerY + player.direction.y * 14);
+  ctx.stroke();
+
+  ctx.restore();
+}
 
 export interface HUDState {
   fps: number;
@@ -7,7 +74,18 @@ export interface HUDState {
   messages: HUDMessage[];
 }
 
-export function renderHUD(ctx: CanvasRenderingContext2D, canvas: HTMLCanvasElement, player: PlayerState, weapon: WeaponDefinition, hud: HUDState, settings: Settings) {
+export function renderHUD(
+  ctx: CanvasRenderingContext2D,
+  canvas: HTMLCanvasElement,
+  player: PlayerState,
+  weapon: WeaponDefinition,
+  hud: HUDState,
+  settings: Settings,
+  level: LevelDefinition,
+  sprites: SpriteRenderable[]
+) {
+  renderMinimap(ctx, canvas, level, player, sprites, settings);
+
   const hudHeight = config.hudHeight;
   ctx.save();
   ctx.fillStyle = 'rgba(15, 10, 25, 0.85)';

--- a/src/input.ts
+++ b/src/input.ts
@@ -12,6 +12,8 @@ export class InputManager {
   private interact = false;
   private pause = false;
   private debugToggle = false;
+  private turnLeft = false;
+  private turnRight = false;
   private wheelWeapon: Settings['leftHanded'];
 
   constructor(settings: Settings) {
@@ -68,9 +70,13 @@ export class InputManager {
     const key = event.key.toLowerCase();
     switch (key) {
       case 'w':
+      case 'arrowup':
+        if (event.key === 'ArrowUp') event.preventDefault();
         this.keys['forward'] = down;
         break;
       case 's':
+      case 'arrowdown':
+        if (event.key === 'ArrowDown') event.preventDefault();
         this.keys['back'] = down;
         break;
       case 'a':
@@ -78,6 +84,14 @@ export class InputManager {
         break;
       case 'd':
         this.keys['right'] = down;
+        break;
+      case 'arrowleft':
+        event.preventDefault();
+        this.turnLeft = down;
+        break;
+      case 'arrowright':
+        event.preventDefault();
+        this.turnRight = down;
         break;
       case ' ':
         this.fireHeld = down;
@@ -112,6 +126,8 @@ export class InputManager {
     this.interact = false;
     this.pause = false;
     this.debugToggle = false;
+    this.turnLeft = false;
+    this.turnRight = false;
   }
 
   consumeWeaponSlot(): InputState['weaponSlot'] {
@@ -141,7 +157,9 @@ export class InputManager {
   getState(delta: number): InputState {
     const forward = (this.keys['forward'] ? 1 : 0) - (this.keys['back'] ? 1 : 0);
     const strafe = (this.keys['right'] ? 1 : 0) - (this.keys['left'] ? 1 : 0);
-    const turning = this.pointerLocked ? clamp(this.mouseDelta * this.settings.lookSensitivity, -0.2, 0.2) : 0;
+    const pointerTurn = this.pointerLocked ? clamp(this.mouseDelta * this.settings.lookSensitivity, -0.2, 0.2) : 0;
+    const keyboardTurn = ((this.turnRight ? 1 : 0) - (this.turnLeft ? 1 : 0)) * 0.05;
+    const turning = clamp(pointerTurn + keyboardTurn, -0.3, 0.3);
     const state: InputState = {
       forward,
       strafe,

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -115,6 +115,6 @@ export class Renderer {
 
     this.ctx.imageSmoothingEnabled = false;
     this.ctx.drawImage(this.view, 0, 0, this.canvas.width, this.canvas.height);
-    renderHUD(this.ctx, this.canvas, player, weapon, hud, settings);
+    renderHUD(this.ctx, this.canvas, player, weapon, hud, settings, raycaster.level, sprites);
   }
 }


### PR DESCRIPTION
## Summary
- enable arrow key movement and turning so players can move without pointer lock
- render a minimap in the HUD that highlights walls, the player, enemies, and pickups for navigation

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d66295dae08333ba20ecb7c33a0484