### PR TITLE
Adjust level1 spawn point

### DIFF
--- a/src/level1.js
+++ b/src/level1.js
@@ -30,7 +30,7 @@ export const level1 = {
   height: mapRows.length,
   tiles: mapRows.flatMap((row) => row.split('').map((cell) => Number(cell))),
   textureLookup: [0, 0],
-  playerStart: { x: 2.5, y: 2.5 },
+  playerStart: { x: 3.5, y: 3.5 },
   enemies: [
     { position: { x: 6.5, y: 6.5 }, type: 'grunt' },
     { position: { x: 10.5, y: 4.5 }, type: 'grunt' },


### PR DESCRIPTION
## Summary
- move the level1 player spawn to an open tile so the player no longer starts inside a wall

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d66fbf8a188333adddbd3acde84330