### PR TITLE
Adjust pointer lock availability checks

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -36,7 +36,9 @@ export class InputManager {
       }
       if (!this.pointerLocked && this.shouldPointerLock()) {
         const canvas = document.querySelector('canvas');
-        canvas?.requestPointerLock?.();
+        if (canvas && typeof canvas.requestPointerLock === 'function') {
+          canvas.requestPointerLock();
+        }
       }
     });
     window.addEventListener('mouseup', (e) => {
@@ -62,7 +64,12 @@ export class InputManager {
   }
 
   private shouldPointerLock(): boolean {
-    return !('ontouchstart' in window) && !this.settings.touchEnabled;
+    const pointerLockAvailable =
+      typeof document !== 'undefined' &&
+      (typeof document.body?.requestPointerLock === 'function' ||
+        typeof document.documentElement?.requestPointerLock === 'function');
+
+    return pointerLockAvailable && !this.settings.touchEnabled;
   }
 
   private onKey(event: KeyboardEvent, down: boolean) {


### PR DESCRIPTION
## Summary
- relax pointer-lock eligibility to rely on Pointer Lock API support instead of touch presence
- guard pointer-lock request with an explicit availability check before invoking the API

## Testing
- `npm run build` *(fails: Missing script "build")*


------
https://chatgpt.com/codex/tasks/task_e_68d673472ebc8333b4c1d1b3238a6fc7