### PR TITLE
Ensure touch look pad controls rotation

### DIFF
--- a/src/touch.ts
+++ b/src/touch.ts
@@ -322,10 +322,8 @@ export class TouchControls {
     }
     const move = this.getMoveVector();
     const forward = -move.y;
-    const turningFromMove = this.lookPointer ? 0 : clamp(-move.x * 0.24, -0.35, 0.35);
-    const strafe = this.lookPointer ? move.x : 0;
-    const turningFromLookPad = clamp(-this.lookDelta * 0.003, -0.45, 0.45);
-    const turning = clamp(turningFromMove + turningFromLookPad, -0.45, 0.45);
+    const strafe = move.x;
+    const turning = clamp(-this.lookDelta * 0.003, -0.45, 0.45);
     const fire = this.fireHeld;
     const interact = this.interactHeld;
     const weaponSlot = this.weaponQueued;


### PR DESCRIPTION
## Summary
- simplify touch control state handling to compute strafing directly from the move stick
- derive turning solely from the look pad delta so rotation is only driven by the right pad

## Testing
- npm run build *(fails: Missing script "build")*

------
https://chatgpt.com/codex/tasks/task_e_68d73727608883338d1a380df9dc5254