### PR TITLE
Fix touch joystick strafing behaviour

### DIFF
--- a/src/touch.ts
+++ b/src/touch.ts
@@ -322,10 +322,9 @@ export class TouchControls {
     }
     const move = this.getMoveVector();
     const forward = -move.y;
-    const turningFromMove = this.lookPointer ? 0 : clamp(-move.x * 0.24, -0.35, 0.35);
-    const strafe = this.lookPointer ? move.x : 0;
+    const strafe = move.x;
     const turningFromLookPad = clamp(-this.lookDelta * 0.003, -0.45, 0.45);
-    const turning = clamp(turningFromMove + turningFromLookPad, -0.45, 0.45);
+    const turning = turningFromLookPad;
     const fire = this.fireHeld;
     const interact = this.interactHeld;
     const weaponSlot = this.weaponQueued;


### PR DESCRIPTION
## Summary
- derive the strafe axis directly from the movement joystick horizontal value
- remove the movement joystick's contribution to turning so only the look pad controls rotation

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d7389a87f883339aba458af8d229a8