### PR TITLE
Adjust touch strafing and rotation logic

### DIFF
--- a/src/touch.js
+++ b/src/touch.js
@@ -313,10 +313,8 @@ export class TouchControls {
     }
     const move = this.getMoveVector();
     const forward = -move.y;
-    const turningFromMove = this.lookPointer ? 0 : clamp(-move.x * 0.24, -0.35, 0.35);
-    const strafe = this.lookPointer ? move.x : 0;
-    const turningFromLookPad = clamp(-this.lookDelta * 0.003, -0.45, 0.45);
-    const turning = clamp(turningFromMove + turningFromLookPad, -0.45, 0.45);
+    const strafe = move.x;
+    const turning = clamp(-this.lookDelta * 0.003, -0.45, 0.45);
     const fire = this.fireHeld;
     const interact = this.interactHeld;
     const weaponSlot = this.weaponQueued;


### PR DESCRIPTION
## Summary
- always source strafing from the movement joystick input
- rely solely on the look pad delta for touch turning

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d73bee8a5c8333ae50deb4d1b54a06