### PR TITLE
Fix touch turning direction

### DIFF
--- a/src/touch.js
+++ b/src/touch.js
@@ -313,8 +313,10 @@ export class TouchControls {
     }
     const move = this.getMoveVector();
     const forward = -move.y;
-    const strafe = move.x;
-    const turning = clamp(-this.lookDelta * 0.003, -0.45, 0.45);
+    const turningFromMove = this.lookPointer ? 0 : clamp(move.x * 0.24, -0.35, 0.35);
+    const strafe = this.lookPointer ? move.x : 0;
+    const turningFromLookPad = clamp(this.lookDelta * 0.003, -0.45, 0.45);
+    const turning = clamp(turningFromMove + turningFromLookPad, -0.45, 0.45);
     const fire = this.fireHeld;
     const interact = this.interactHeld;
     const weaponSlot = this.weaponQueued;

--- a/src/touch.ts
+++ b/src/touch.ts
@@ -322,9 +322,9 @@ export class TouchControls {
     }
     const move = this.getMoveVector();
     const forward = -move.y;
-    const turningFromMove = this.lookPointer ? 0 : clamp(-move.x * 0.24, -0.35, 0.35);
+    const turningFromMove = this.lookPointer ? 0 : clamp(move.x * 0.24, -0.35, 0.35);
     const strafe = this.lookPointer ? move.x : 0;
-    const turningFromLookPad = clamp(-this.lookDelta * 0.003, -0.45, 0.45);
+    const turningFromLookPad = clamp(this.lookDelta * 0.003, -0.45, 0.45);
     const turning = clamp(turningFromMove + turningFromLookPad, -0.45, 0.45);
     const fire = this.fireHeld;
     const interact = this.interactHeld;


### PR DESCRIPTION
## Summary
- flip the horizontal move contribution to touch turning so right swipes rotate right
- update the generated JavaScript mirror to match the corrected TypeScript logic

## Testing
- `node --input-type=module <<'NODE'; import { TouchControls } from './src/touch.js'; const stub = { visible: true, lookPointer: null, getMoveVector() { return { x: 1, y: 0 }; }, fireHeld: false, interactHeld: false, weaponQueued: null, pausedRequested: false, lookDelta: 10 }; console.log(TouchControls.prototype.getState.call(stub)); NODE`
- `node --input-type=module <<'NODE'; import { TouchControls } from './src/touch.js'; const stub = { visible: true, lookPointer: { active: true }, getMoveVector() { return { x: 1, y: 0 }; }, fireHeld: false, interactHeld: false, weaponQueued: null, pausedRequested: false, lookDelta: 10 }; console.log(TouchControls.prototype.getState.call(stub)); NODE`


------
https://chatgpt.com/codex/tasks/task_e_68d73d28edfc8333b53912e8c09a6692