### PR TITLE
Fix touch joystick strafing behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "raycast-retro",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "raycast-retro",
+      "version": "0.1.0"
+    }
+  }
+}

--- a/src/touch.ts
+++ b/src/touch.ts
@@ -322,10 +322,9 @@ export class TouchControls {
     }
     const move = this.getMoveVector();
     const forward = -move.y;
-    const turningFromMove = this.lookPointer ? 0 : clamp(move.x * 0.24, -0.35, 0.35);
-    const strafe = this.lookPointer ? move.x : 0;
+    const strafe = move.x;
     const turningFromLookPad = clamp(this.lookDelta * 0.003, -0.45, 0.45);
-    const turning = clamp(turningFromMove + turningFromLookPad, -0.45, 0.45);
+    const turning = clamp(turningFromLookPad, -0.45, 0.45);
     const fire = this.fireHeld;
     const interact = this.interactHeld;
     const weaponSlot = this.weaponQueued;


### PR DESCRIPTION
## Summary
- ensure the touch joystick always maps horizontal movement to strafing input
- remove automatic turning derived from the movement stick so turning comes from the look pad
- add the generated npm lockfile

## Testing
- npm install
- npm run build *(fails: Missing script "build")*


------
https://chatgpt.com/codex/tasks/task_e_68d73f257bd483339cf4ddbcad8c7291