### PR TITLE
feat: remap virtual joysticks and add touch control config

### DIFF
--- a/src/config/controls.js
+++ b/src/config/controls.js
@@ -1,0 +1,9 @@
+export const deadzone = 0.12;
+export const moveSpeed = 4.0;
+export const turnSpeed = 2.2;
+export const pitchSpeed = 1.2;
+export let invertLookY = false;
+
+export function setInvertLookY(value) {
+  invertLookY = Boolean(value);
+}

--- a/src/config/controls.ts
+++ b/src/config/controls.ts
@@ -1,0 +1,9 @@
+export const deadzone = 0.12;
+export const moveSpeed = 4.0;
+export const turnSpeed = 2.2;
+export const pitchSpeed = 1.2;
+export let invertLookY = false;
+
+export function setInvertLookY(value: boolean) {
+  invertLookY = Boolean(value);
+}

--- a/src/controls/virtualJoysticks.js
+++ b/src/controls/virtualJoysticks.js
@@ -1,0 +1,188 @@
+import { deadzone } from '../config/controls.js';
+
+const sticks = {
+  left: createStickState('joy-left'),
+  right: createStickState('joy-right')
+};
+
+let initialized = false;
+const listeners = [];
+
+function createStickState(id) {
+  return {
+    id,
+    el: null,
+    knob: null,
+    pointerId: null,
+    target: { x: 0, y: 0 },
+    visual: { x: 0, y: 0 },
+    smoothed: { x: 0, y: 0 }
+  };
+}
+
+function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+function applyDeadzone(vx, vy, dz = deadzone) {
+  const mag = Math.hypot(vx, vy);
+  if (mag === 0) {
+    return { x: 0, y: 0 };
+  }
+  if (mag < dz) {
+    return { x: 0, y: 0 };
+  }
+  const scaled = Math.min(1, (mag - dz) / (1 - dz));
+  const nx = (vx / mag) * scaled;
+  const ny = (vy / mag) * scaled;
+  return { x: nx, y: ny };
+}
+
+function clampVector(vx, vy) {
+  const mag = Math.hypot(vx, vy);
+  if (mag > 1) {
+    return { x: vx / mag, y: vy / mag };
+  }
+  return { x: vx, y: vy };
+}
+
+function attachStick(stick, el) {
+  stick.el = el;
+  stick.el.id = stick.id;
+  stick.el.classList.add('vj');
+  stick.el.style.touchAction = 'none';
+  stick.el.style.userSelect = 'none';
+
+  const nub = document.createElement('div');
+  nub.className = 'nub';
+  stick.knob = nub;
+  stick.el.appendChild(nub);
+
+  const pointerDown = (event) => {
+    if (stick.pointerId !== null) return;
+    stick.pointerId = event.pointerId;
+    if (event.pointerType === 'touch') {
+      event.preventDefault();
+    }
+    stick.el.setPointerCapture(event.pointerId);
+    updateStickFromEvent(stick, event);
+  };
+
+  const pointerMove = (event) => {
+    if (stick.pointerId !== event.pointerId) return;
+    if (event.pointerType === 'touch') {
+      event.preventDefault();
+    }
+    updateStickFromEvent(stick, event);
+  };
+
+  const endHandler = (event) => {
+    if (stick.pointerId !== event.pointerId) return;
+    if (stick.el.hasPointerCapture(event.pointerId)) {
+      stick.el.releasePointerCapture(event.pointerId);
+    }
+    resetStick(stick);
+  };
+
+  stick.el.addEventListener('pointerdown', pointerDown, { passive: false });
+  window.addEventListener('pointermove', pointerMove, { passive: false });
+  window.addEventListener('pointerup', endHandler);
+  window.addEventListener('pointercancel', endHandler);
+  window.addEventListener('pointerout', endHandler);
+  window.addEventListener('pointerleave', endHandler);
+
+  listeners.push({ type: 'pointerdown', target: stick.el, handler: pointerDown });
+  listeners.push({ type: 'pointermove', target: window, handler: pointerMove });
+  listeners.push({ type: 'pointerup', target: window, handler: endHandler });
+  listeners.push({ type: 'pointercancel', target: window, handler: endHandler });
+  listeners.push({ type: 'pointerout', target: window, handler: endHandler });
+  listeners.push({ type: 'pointerleave', target: window, handler: endHandler });
+}
+
+function updateStickFromEvent(stick, event) {
+  const rect = stick.el.getBoundingClientRect();
+  const centerX = rect.left + rect.width / 2;
+  const centerY = rect.top + rect.height / 2;
+  const radius = rect.width / 2 || 1;
+  const rawX = (event.clientX - centerX) / radius;
+  const rawY = (event.clientY - centerY) / radius;
+  const clamped = clampVector(rawX, rawY);
+  const dz = applyDeadzone(clamped.x, clamped.y);
+  stick.visual = clamped;
+  stick.target = dz;
+  updateKnob(stick);
+}
+
+function updateKnob(stick) {
+  if (!stick.knob || !stick.el) return;
+  const maxOffset = stick.el.clientWidth * 0.5 - stick.knob.clientWidth * 0.5;
+  const offsetX = stick.visual.x * maxOffset;
+  const offsetY = stick.visual.y * maxOffset;
+  stick.knob.style.transform = `translate(calc(-50% + ${offsetX}px), calc(-50% + ${offsetY}px))`;
+}
+
+function resetStick(stick) {
+  stick.pointerId = null;
+  stick.target = { x: 0, y: 0 };
+  stick.visual = { x: 0, y: 0 };
+  updateKnob(stick);
+}
+
+function smoothStick(stick) {
+  stick.smoothed.x = lerp(stick.smoothed.x, stick.target.x, 0.25);
+  stick.smoothed.y = lerp(stick.smoothed.y, stick.target.y, 0.25);
+  if (Math.abs(stick.smoothed.x) < 0.0001) stick.smoothed.x = 0;
+  if (Math.abs(stick.smoothed.y) < 0.0001) stick.smoothed.y = 0;
+  return { x: stick.smoothed.x, y: stick.smoothed.y };
+}
+
+export function initVirtualJoysticks({ leftEl, rightEl }) {
+  if (initialized) return;
+  if (!leftEl || !rightEl) {
+    throw new Error('Virtual joystick elements are required');
+  }
+  attachStick(sticks.left, leftEl);
+  attachStick(sticks.right, rightEl);
+  initialized = true;
+}
+
+export function getLeftVector() {
+  return smoothStick(sticks.left);
+}
+
+export function getRightVector() {
+  return smoothStick(sticks.right);
+}
+
+export function resetVirtualJoysticks() {
+  resetStick(sticks.left);
+  resetStick(sticks.right);
+  sticks.left.smoothed = { x: 0, y: 0 };
+  sticks.right.smoothed = { x: 0, y: 0 };
+}
+
+export function teardownVirtualJoysticks() {
+  if (!initialized) return;
+  resetVirtualJoysticks();
+  for (const { type, target, handler } of listeners.splice(0, listeners.length)) {
+    target.removeEventListener(type, handler);
+  }
+  if (sticks.left.knob && sticks.left.knob.parentElement) {
+    sticks.left.knob.parentElement.removeChild(sticks.left.knob);
+  }
+  if (sticks.right.knob && sticks.right.knob.parentElement) {
+    sticks.right.knob.parentElement.removeChild(sticks.right.knob);
+  }
+  sticks.left.el = null;
+  sticks.right.el = null;
+  sticks.left.knob = null;
+  sticks.right.knob = null;
+  initialized = false;
+}
+
+export function getStickDebug() {
+  return {
+    left: { ...sticks.left.target },
+    right: { ...sticks.right.target }
+  };
+}

--- a/src/controls/virtualJoysticks.ts
+++ b/src/controls/virtualJoysticks.ts
@@ -1,0 +1,196 @@
+import { deadzone } from '../config/controls';
+
+type StickState = {
+  id: string;
+  el: HTMLDivElement | null;
+  knob: HTMLDivElement | null;
+  pointerId: number | null;
+  target: { x: number; y: number };
+  visual: { x: number; y: number };
+  smoothed: { x: number; y: number };
+};
+
+const sticks: Record<'left' | 'right', StickState> = {
+  left: createStickState('joy-left'),
+  right: createStickState('joy-right')
+};
+
+let initialized = false;
+const listeners: Array<{ type: string; target: EventTarget; handler: EventListenerOrEventListenerObject }> = [];
+
+function createStickState(id: string): StickState {
+  return {
+    id,
+    el: null,
+    knob: null,
+    pointerId: null,
+    target: { x: 0, y: 0 },
+    visual: { x: 0, y: 0 },
+    smoothed: { x: 0, y: 0 }
+  };
+}
+
+function lerp(a: number, b: number, t: number) {
+  return a + (b - a) * t;
+}
+
+function applyDeadzone(vx: number, vy: number, dz = deadzone) {
+  const mag = Math.hypot(vx, vy);
+  if (mag === 0 || mag < dz) {
+    return { x: 0, y: 0 };
+  }
+  const scaled = Math.min(1, (mag - dz) / (1 - dz));
+  const nx = (vx / mag) * scaled;
+  const ny = (vy / mag) * scaled;
+  return { x: nx, y: ny };
+}
+
+function clampVector(vx: number, vy: number) {
+  const mag = Math.hypot(vx, vy);
+  if (mag > 1) {
+    return { x: vx / mag, y: vy / mag };
+  }
+  return { x: vx, y: vy };
+}
+
+function attachStick(stick: StickState, el: HTMLDivElement) {
+  stick.el = el;
+  stick.el.id = stick.id;
+  stick.el.classList.add('vj');
+  stick.el.style.touchAction = 'none';
+  stick.el.style.userSelect = 'none';
+
+  const nub = document.createElement('div');
+  nub.className = 'nub';
+  stick.knob = nub;
+  stick.el.appendChild(nub);
+
+  const pointerDown = (event: PointerEvent) => {
+    if (stick.pointerId !== null) return;
+    stick.pointerId = event.pointerId;
+    if (event.pointerType === 'touch') {
+      event.preventDefault();
+    }
+    stick.el?.setPointerCapture(event.pointerId);
+    updateStickFromEvent(stick, event);
+  };
+
+  const pointerMove = (event: PointerEvent) => {
+    if (stick.pointerId !== event.pointerId) return;
+    if (event.pointerType === 'touch') {
+      event.preventDefault();
+    }
+    updateStickFromEvent(stick, event);
+  };
+
+  const endHandler = (event: PointerEvent) => {
+    if (stick.pointerId !== event.pointerId) return;
+    if (stick.el && stick.el.hasPointerCapture(event.pointerId)) {
+      stick.el.releasePointerCapture(event.pointerId);
+    }
+    resetStick(stick);
+  };
+
+  stick.el.addEventListener('pointerdown', pointerDown, { passive: false });
+  window.addEventListener('pointermove', pointerMove, { passive: false });
+  window.addEventListener('pointerup', endHandler);
+  window.addEventListener('pointercancel', endHandler);
+  window.addEventListener('pointerout', endHandler);
+  window.addEventListener('pointerleave', endHandler);
+
+  listeners.push({ type: 'pointerdown', target: stick.el, handler: pointerDown });
+  listeners.push({ type: 'pointermove', target: window, handler: pointerMove });
+  listeners.push({ type: 'pointerup', target: window, handler: endHandler });
+  listeners.push({ type: 'pointercancel', target: window, handler: endHandler });
+  listeners.push({ type: 'pointerout', target: window, handler: endHandler });
+  listeners.push({ type: 'pointerleave', target: window, handler: endHandler });
+}
+
+function updateStickFromEvent(stick: StickState, event: PointerEvent) {
+  if (!stick.el) return;
+  const rect = stick.el.getBoundingClientRect();
+  const centerX = rect.left + rect.width / 2;
+  const centerY = rect.top + rect.height / 2;
+  const radius = rect.width / 2 || 1;
+  const rawX = (event.clientX - centerX) / radius;
+  const rawY = (event.clientY - centerY) / radius;
+  const clamped = clampVector(rawX, rawY);
+  const dz = applyDeadzone(clamped.x, clamped.y);
+  stick.visual = clamped;
+  stick.target = dz;
+  updateKnob(stick);
+}
+
+function updateKnob(stick: StickState) {
+  if (!stick.knob || !stick.el) return;
+  const maxOffset = stick.el.clientWidth * 0.5 - stick.knob.clientWidth * 0.5;
+  const offsetX = stick.visual.x * maxOffset;
+  const offsetY = stick.visual.y * maxOffset;
+  stick.knob.style.transform = `translate(calc(-50% + ${offsetX}px), calc(-50% + ${offsetY}px))`;
+}
+
+function resetStick(stick: StickState) {
+  stick.pointerId = null;
+  stick.target = { x: 0, y: 0 };
+  stick.visual = { x: 0, y: 0 };
+  updateKnob(stick);
+}
+
+function smoothStick(stick: StickState) {
+  stick.smoothed.x = lerp(stick.smoothed.x, stick.target.x, 0.25);
+  stick.smoothed.y = lerp(stick.smoothed.y, stick.target.y, 0.25);
+  if (Math.abs(stick.smoothed.x) < 0.0001) stick.smoothed.x = 0;
+  if (Math.abs(stick.smoothed.y) < 0.0001) stick.smoothed.y = 0;
+  return { x: stick.smoothed.x, y: stick.smoothed.y };
+}
+
+export function initVirtualJoysticks({ leftEl, rightEl }: { leftEl: HTMLDivElement; rightEl: HTMLDivElement }) {
+  if (initialized) return;
+  if (!leftEl || !rightEl) {
+    throw new Error('Virtual joystick elements are required');
+  }
+  attachStick(sticks.left, leftEl);
+  attachStick(sticks.right, rightEl);
+  initialized = true;
+}
+
+export function getLeftVector() {
+  return smoothStick(sticks.left);
+}
+
+export function getRightVector() {
+  return smoothStick(sticks.right);
+}
+
+export function resetVirtualJoysticks() {
+  resetStick(sticks.left);
+  resetStick(sticks.right);
+  sticks.left.smoothed = { x: 0, y: 0 };
+  sticks.right.smoothed = { x: 0, y: 0 };
+}
+
+export function teardownVirtualJoysticks() {
+  if (!initialized) return;
+  resetVirtualJoysticks();
+  for (const { type, target, handler } of listeners.splice(0, listeners.length)) {
+    target.removeEventListener(type, handler as EventListener);
+  }
+  if (sticks.left.knob && sticks.left.knob.parentElement) {
+    sticks.left.knob.parentElement.removeChild(sticks.left.knob);
+  }
+  if (sticks.right.knob && sticks.right.knob.parentElement) {
+    sticks.right.knob.parentElement.removeChild(sticks.right.knob);
+  }
+  sticks.left.el = null;
+  sticks.right.el = null;
+  sticks.left.knob = null;
+  sticks.right.knob = null;
+  initialized = false;
+}
+
+export function getStickDebug() {
+  return {
+    left: { ...sticks.left.target },
+    right: { ...sticks.right.target }
+  };
+}

--- a/src/touch.js
+++ b/src/touch.js
@@ -1,6 +1,15 @@
-import { clamp, length } from './math.js';
+import { clamp } from './math.js';
+import {
+  initVirtualJoysticks,
+  getLeftVector,
+  getRightVector,
+  resetVirtualJoysticks
+} from './controls/virtualJoysticks.js';
+import { turnSpeed, pitchSpeed, invertLookY } from './config/controls.js';
 
-const DEADZONE = 0.12;
+function formatStickValue(label, value) {
+  return `${label}:${value.toFixed(2)}`;
+}
 
 export class TouchControls {
   constructor(settings) {
@@ -9,17 +18,20 @@ export class TouchControls {
     this.container.className = 'touch-container';
     this.container.style.cssText = 'position:fixed;inset:0;pointer-events:none;font-family:inherit;';
 
-    this.joystick = document.createElement('div');
-    this.joystick.className = 'touch-joystick';
-    this.joystickKnob = document.createElement('div');
-    this.joystickKnob.className = 'touch-joystick-knob';
-    this.joystick.appendChild(this.joystickKnob);
+    this.leftStick = document.createElement('div');
+    this.leftStick.id = 'joy-left';
 
-    this.lookPad = document.createElement('div');
-    this.lookPad.className = 'touch-lookpad';
+    this.rightStick = document.createElement('div');
+    this.rightStick.id = 'joy-right';
 
     this.rightControls = document.createElement('div');
     this.rightControls.className = 'touch-right-controls';
+
+    this.fireHeld = false;
+    this.interactHeld = false;
+    this.weaponQueued = null;
+    this.pausedRequested = false;
+    this.visible = false;
 
     this.fireButton = this.createButton('Fire');
     this.interactButton = this.createButton('Interact');
@@ -34,21 +46,18 @@ export class TouchControls {
     this.toggleButton.className = 'touch-toggle';
     this.toggleButton.style.cssText = 'position:fixed;top:12px;left:12px;font-size:12px;opacity:0.5;z-index:20;';
 
+    this.debugReadout = document.createElement('div');
+    this.debugReadout.className = 'touch-debug';
+    this.debugReadout.style.cssText =
+      'position:fixed;bottom:12px;left:50%;transform:translateX(-50%);font-size:12px;color:#fff;pointer-events:none;opacity:0.75;text-shadow:0 1px 2px rgba(0,0,0,0.8);font-family:monospace;';
+    this.debugReadout.textContent = 'LX:0.00 LY:0.00 RX:0.00 RY:0.00';
+
     this.toggleButton.addEventListener('click', () => {
       this.setVisible(!this.visible);
       this.settings.touchEnabled = this.visible;
       localStorage.setItem('raycast-retro-touch', JSON.stringify({ enabled: this.visible }));
       this.updateToggleLabel();
     });
-
-    this.movePointer = null;
-    this.lookPointer = null;
-    this.lookDelta = 0;
-    this.fireHeld = false;
-    this.interactHeld = false;
-    this.weaponQueued = null;
-    this.pausedRequested = false;
-    this.visible = false;
 
     if (this.isTouchDevice()) {
       this.toggleButton.style.display = 'none';
@@ -66,7 +75,7 @@ export class TouchControls {
       }
     }
 
-    this.container.appendChild(this.joystick);
+    this.container.appendChild(this.leftStick);
     this.buttonCluster = document.createElement('div');
     this.buttonCluster.className = 'touch-buttons';
     this.buttonCluster.style.cssText = 'display:flex;flex-direction:column;gap:12px;pointer-events:auto;';
@@ -92,17 +101,21 @@ export class TouchControls {
     this.buttonCluster.appendChild(actionRow);
     this.buttonCluster.appendChild(this.pauseButton);
 
-    this.rightControls.appendChild(this.lookPad);
+    this.rightControls.appendChild(this.rightStick);
     this.rightControls.appendChild(this.buttonCluster);
     this.container.appendChild(this.rightControls);
 
     document.body.appendChild(this.container);
     document.body.appendChild(this.toggleButton);
+    document.body.appendChild(this.debugReadout);
+
+    initVirtualJoysticks({ leftEl: this.leftStick, rightEl: this.rightStick });
+
     this.setVisible(this.settings.touchEnabled || this.isTouchDevice());
     this.updateToggleLabel();
     this.applyStyles();
     this.attachPointerListeners();
-    this.updateJoystickVisual();
+    this.updateDebugReadout({ x: 0, y: 0 }, { x: 0, y: 0 });
   }
 
   isTouchDevice() {
@@ -118,7 +131,8 @@ export class TouchControls {
     btn.textContent = label;
     btn.type = 'button';
     btn.className = 'touch-button';
-    btn.style.cssText = 'width:72px;height:72px;border-radius:50%;border:none;background:rgba(255,255,255,0.65);color:#111;font-weight:bold;pointer-events:auto;touch-action:none;';
+    btn.style.cssText =
+      'width:72px;height:72px;border-radius:50%;border:none;background:rgba(255,255,255,0.65);color:#111;font-weight:bold;pointer-events:auto;touch-action:none;';
     btn.addEventListener('pointerdown', (e) => {
       e.preventDefault();
       btn.setAttribute('data-active', '1');
@@ -134,144 +148,92 @@ export class TouchControls {
 
   attachPointerListeners() {
     const pointerOptions = { passive: false };
-    this.joystick.addEventListener('pointerdown', (e) => this.beginMove(e), pointerOptions);
-    this.lookPad.addEventListener('pointerdown', (e) => this.beginLook(e), pointerOptions);
-    window.addEventListener('pointermove', (e) => this.onPointerMove(e), pointerOptions);
-    window.addEventListener('pointerup', (e) => this.endPointer(e));
-    window.addEventListener('pointercancel', (e) => this.endPointer(e));
 
-    this.fireButton.addEventListener('pointerdown', (e) => {
-      e.preventDefault();
-      this.fireHeld = true;
-    });
-    this.fireButton.addEventListener('pointerup', () => {
-      this.fireHeld = false;
-    });
-    this.fireButton.addEventListener('pointercancel', () => {
-      this.fireHeld = false;
-    });
+    this.fireButton.addEventListener(
+      'pointerdown',
+      (e) => {
+        e.preventDefault();
+        this.fireHeld = true;
+      },
+      pointerOptions
+    );
+    this.fireButton.addEventListener('pointerup', () => (this.fireHeld = false));
+    this.fireButton.addEventListener('pointercancel', () => (this.fireHeld = false));
 
-    this.interactButton.addEventListener('pointerdown', (e) => {
-      e.preventDefault();
-      this.interactHeld = true;
-    });
-    this.interactButton.addEventListener('pointerup', () => {
-      this.interactHeld = false;
-    });
-    this.interactButton.addEventListener('pointercancel', () => {
-      this.interactHeld = false;
-    });
+    this.interactButton.addEventListener(
+      'pointerdown',
+      (e) => {
+        e.preventDefault();
+        this.interactHeld = true;
+      },
+      pointerOptions
+    );
+    this.interactButton.addEventListener('pointerup', () => (this.interactHeld = false));
+    this.interactButton.addEventListener('pointercancel', () => (this.interactHeld = false));
 
-    this.pauseButton.addEventListener('pointerdown', (e) => {
-      e.preventDefault();
-      this.pausedRequested = true;
-    });
-  }
-
-  beginMove(e) {
-    if (this.movePointer) return;
-    this.movePointer = {
-      id: e.pointerId,
-      startX: e.clientX,
-      startY: e.clientY,
-      currentX: e.clientX,
-      currentY: e.clientY,
-      active: true
-    };
-    this.updateJoystickVisual();
-    this.joystick.setPointerCapture(e.pointerId);
-  }
-
-  beginLook(e) {
-    if (this.lookPointer) return;
-    this.lookPointer = {
-      id: e.pointerId,
-      startX: e.clientX,
-      startY: e.clientY,
-      currentX: e.clientX,
-      currentY: e.clientY,
-      active: true
-    };
-    this.lookPad.setPointerCapture(e.pointerId);
-  }
-
-  onPointerMove(e) {
-    if (this.movePointer && this.movePointer.id === e.pointerId) {
-      this.movePointer.currentX = e.clientX;
-      this.movePointer.currentY = e.clientY;
-      this.updateJoystickVisual();
-    }
-    if (this.lookPointer && this.lookPointer.id === e.pointerId) {
-      const dx = e.clientX - this.lookPointer.currentX;
-      this.lookPointer.currentX = e.clientX;
-      this.lookPointer.currentY = e.clientY;
-      this.lookDelta += dx;
-    }
-  }
-
-  endPointer(e) {
-    if (this.movePointer && this.movePointer.id === e.pointerId) {
-      this.joystick.releasePointerCapture(e.pointerId);
-      this.movePointer = null;
-      this.updateJoystickVisual();
-    }
-    if (this.lookPointer && this.lookPointer.id === e.pointerId) {
-      this.lookPad.releasePointerCapture(e.pointerId);
-      this.lookPointer = null;
-    }
-    if (this.fireHeld && e.target === this.fireButton) {
-      this.fireHeld = false;
-    }
-    if (this.interactHeld && e.target === this.interactButton) {
-      this.interactHeld = false;
-    }
-  }
-
-  updateJoystickVisual() {
-    const size = this.settings.joystickSize;
-    this.joystick.style.width = `${size}px`;
-    this.joystick.style.height = `${size}px`;
-    const knobSize = size * 0.4;
-    const move = this.getMoveVector();
-    const radius = (size - knobSize) / 2;
-    const offsetX = move.x * radius;
-    const offsetY = move.y * radius;
-    this.joystickKnob.style.width = `${knobSize}px`;
-    this.joystickKnob.style.height = `${knobSize}px`;
-    this.joystickKnob.style.transform = `translate(-50%, -50%) translate(${offsetX}px, ${offsetY}px)`;
+    this.pauseButton.addEventListener(
+      'pointerdown',
+      (e) => {
+        e.preventDefault();
+        this.pausedRequested = true;
+      },
+      pointerOptions
+    );
   }
 
   applyStyles() {
     const baseOpacity = this.settings.uiOpacity;
+    const joystickSize = this.settings.joystickSize;
     const joystickSide = this.settings.leftHanded ? 'right' : 'left';
     const joystickOppositeSide = this.settings.leftHanded ? 'left' : 'right';
-    this.joystick.style.cssText = `position:absolute;bottom:20%;${joystickSide}:6%;${joystickOppositeSide}:auto;pointer-events:auto;border-radius:50%;background:rgba(40,40,60,${baseOpacity});backdrop-filter:blur(6px);touch-action:none;display:flex;align-items:center;justify-content:center;`;
-    this.joystickKnob.style.cssText =
-      'position:absolute;top:50%;left:50%;transform:translate(-50%, -50%);background:rgba(255,255,255,0.7);border-radius:50%;transition:background 0.1s;';
-    const lookPadSize = this.settings.joystickSize * 1.1;
-    this.lookPad.style.cssText = `width:${lookPadSize}px;height:${lookPadSize}px;border-radius:18px;background:rgba(40,40,60,${baseOpacity});pointer-events:auto;touch-action:none;`;
+
+    const stickStyle =
+      `position:absolute;bottom:18%;${joystickSide}:6%;${joystickOppositeSide}:auto;width:${joystickSize}px;height:${joystickSize}px;` +
+      `pointer-events:auto;border-radius:50%;background:rgba(40,40,60,${baseOpacity});backdrop-filter:blur(6px);outline:1px solid rgba(255,255,255,${baseOpacity * 0.3});display:flex;align-items:center;justify-content:center;`;
+    this.leftStick.style.cssText = stickStyle;
+
+    const rightStickSize = joystickSize * 1.05;
     const controlsSide = this.settings.leftHanded ? 'left' : 'right';
     const controlsOppositeSide = this.settings.leftHanded ? 'right' : 'left';
     const alignItems = this.settings.leftHanded ? 'flex-start' : 'flex-end';
-    this.rightControls.style.cssText = `position:absolute;bottom:18%;${controlsSide}:4%;${controlsOppositeSide}:auto;display:flex;flex-direction:column;align-items:${alignItems};gap:18px;pointer-events:auto;`;
+
+    this.rightStick.style.cssText =
+      `width:${rightStickSize}px;height:${rightStickSize}px;border-radius:18px;background:rgba(40,40,60,${baseOpacity});pointer-events:auto;touch-action:none;position:relative;`;
+
+    this.rightControls.style.cssText =
+      `position:absolute;bottom:16%;${controlsSide}:4%;${controlsOppositeSide}:auto;display:flex;flex-direction:column;align-items:${alignItems};gap:18px;pointer-events:auto;`;
+
     this.buttonCluster.style.alignItems = alignItems;
     this.fireButton.style.background = `rgba(255,120,80,${baseOpacity + 0.2})`;
     this.interactButton.style.background = `rgba(120,200,255,${baseOpacity + 0.2})`;
-    this.pauseButton.style.cssText = 'width:64px;height:64px;border-radius:18px;border:none;background:rgba(255,255,255,0.6);font-weight:bold;';
+    this.pauseButton.style.cssText =
+      'width:64px;height:64px;border-radius:18px;border:none;background:rgba(255,255,255,0.6);font-weight:bold;touch-action:none;';
     this.pauseButton.style.opacity = `${baseOpacity + 0.1}`;
     this.pauseButton.style.marginTop = '4px';
     this.pauseButton.style.alignSelf = 'flex-end';
-    this.container.style.setProperty('--touch-opacity', `${baseOpacity}`);
-    if (this.visible) {
-      document.body.style.touchAction = 'none';
-    } else {
-      document.body.style.touchAction = '';
+
+    document.body.style.touchAction = this.visible ? 'none' : '';
+
+    const leftNub = this.leftStick.querySelector('.nub');
+    const rightNub = this.rightStick.querySelector('.nub');
+    const leftNubSize = joystickSize * 0.35;
+    const rightNubSize = rightStickSize * 0.22;
+    if (leftNub) {
+      leftNub.style.cssText =
+        `position:absolute;top:50%;left:50%;width:${leftNubSize}px;height:${leftNubSize}px;border-radius:50%;transform:translate(-50%, -50%);` +
+        `background:rgba(255,255,255,0.18);box-shadow:0 2px 6px rgba(0,0,0,0.4);transition:background 0.1s;`;
+    }
+    if (rightNub) {
+      rightNub.style.cssText =
+        `position:absolute;top:50%;left:50%;width:${rightNubSize}px;height:${rightNubSize}px;border-radius:50%;transform:translate(-50%, -50%);` +
+        `background:rgba(255,255,255,0.18);box-shadow:0 2px 6px rgba(0,0,0,0.4);transition:background 0.1s;`;
     }
   }
 
   setVisible(visible) {
     this.visible = visible;
     this.container.style.display = visible ? 'block' : 'none';
+    this.debugReadout.style.display = visible ? 'block' : 'none';
     if (!visible) {
       this.resetState();
     }
@@ -282,48 +244,53 @@ export class TouchControls {
     this.settings = settings;
     this.setVisible(settings.touchEnabled || this.visible);
     this.applyStyles();
-    this.updateJoystickVisual();
+    this.updateToggleLabel();
   }
 
   resetState() {
-    this.movePointer = null;
-    this.lookPointer = null;
-    this.lookDelta = 0;
     this.fireHeld = false;
     this.interactHeld = false;
     this.weaponQueued = null;
+    this.pausedRequested = false;
+    resetVirtualJoysticks();
   }
 
-  getMoveVector() {
-    if (!this.movePointer) return { x: 0, y: 0 };
-    const dx = this.movePointer.currentX - this.movePointer.startX;
-    const dy = this.movePointer.currentY - this.movePointer.startY;
-    const radius = this.settings.joystickSize * 0.5;
-    const nx = clamp(dx / radius, -1, 1);
-    const ny = clamp(dy / radius, -1, 1);
-    const mag = length({ x: nx, y: ny });
-    if (mag < DEADZONE) return { x: 0, y: 0 };
-    const scale = Math.min(1, mag);
-    return { x: nx * scale, y: ny * scale };
+  updateDebugReadout(left = getLeftVector(), right = getRightVector()) {
+    this.debugReadout.textContent = `${formatStickValue('LX', left.x)} ${formatStickValue('LY', left.y)} ${formatStickValue('RX', right.x)} ${formatStickValue('RY', right.y)}`;
   }
 
   getState() {
     if (!this.visible) {
-      return { forward: 0, strafe: 0, turning: 0, fire: false, interact: false };
+      this.updateDebugReadout({ x: 0, y: 0 }, { x: 0, y: 0 });
+      return { forward: 0, strafe: 0, turning: 0, looking: 0, fire: false, interact: false };
     }
-    const move = this.getMoveVector();
-    const forward = -move.y;
-    const turningFromMove = this.lookPointer ? 0 : clamp(move.x * 0.24, -0.35, 0.35);
-    const strafe = this.lookPointer ? move.x : 0;
-    const turningFromLookPad = clamp(this.lookDelta * 0.003, -0.45, 0.45);
-    const turning = clamp(turningFromMove + turningFromLookPad, -0.45, 0.45);
+
+    const left = getLeftVector();
+    const rightRaw = getRightVector();
+    const right = { x: rightRaw.x, y: invertLookY ? -rightRaw.y : rightRaw.y };
+
+    const forward = clamp(-left.y, -1, 1);
+    const strafe = clamp(left.x, -1, 1);
+
+    const lookScale = this.settings.lookSensitivity * 600 || 1;
+    const turnMultiplier = turnSpeed / lookScale;
+    const turning = clamp(right.x * turnMultiplier, -turnMultiplier, turnMultiplier);
+
+    const looking = clamp(-right.y * pitchSpeed, -pitchSpeed, pitchSpeed);
+
     const fire = this.fireHeld;
     const interact = this.interactHeld;
     const weaponSlot = this.weaponQueued;
     this.weaponQueued = null;
+
     const pauseRequested = this.pausedRequested;
     this.pausedRequested = false;
-    this.lookDelta = 0;
-    return { forward, strafe, turning, fire, interact, weaponSlot, pauseRequested };
+    if (pauseRequested) {
+      resetVirtualJoysticks();
+    }
+
+    this.updateDebugReadout(left, rightRaw);
+
+    return { forward, strafe, turning, looking, fire, interact, weaponSlot, pauseRequested };
   }
 }

--- a/src/touch.ts
+++ b/src/touch.ts
@@ -1,22 +1,25 @@
-import { clamp, length } from './math';
-import type { InputState, Settings, Vec2 } from './types';
+import { clamp } from './math';
+import type { InputState, Settings } from './types';
+import {
+  initVirtualJoysticks,
+  getLeftVector,
+  getRightVector,
+  resetVirtualJoysticks
+} from './controls/virtualJoysticks';
+import { turnSpeed, pitchSpeed, invertLookY } from './config/controls';
 
-interface PointerData {
-  id: number;
-  startX: number;
-  startY: number;
-  currentX: number;
-  currentY: number;
-  active: boolean;
+type TouchPersist = {
+  enabled?: boolean;
+};
+
+function formatStickValue(label: string, value: number) {
+  return `${label}:${value.toFixed(2)}`;
 }
-
-const DEADZONE = 0.12;
 
 export class TouchControls {
   private container: HTMLDivElement;
-  private joystick: HTMLDivElement;
-  private joystickKnob: HTMLDivElement;
-  private lookPad: HTMLDivElement;
+  private leftStick: HTMLDivElement;
+  private rightStick: HTMLDivElement;
   private rightControls: HTMLDivElement;
   private buttonCluster: HTMLDivElement;
   private fireButton: HTMLButtonElement;
@@ -24,31 +27,25 @@ export class TouchControls {
   private weaponButtons: HTMLButtonElement[] = [];
   private pauseButton: HTMLButtonElement;
   private toggleButton: HTMLButtonElement;
-  private movePointer: PointerData | null = null;
-  private lookPointer: PointerData | null = null;
-  private lookDelta = 0;
+  private debugReadout: HTMLDivElement;
   private settings: Settings;
   private fireHeld = false;
   private interactHeld = false;
   private weaponQueued: InputState['weaponSlot'] = null;
   private pausedRequested = false;
   private visible = false;
-  private lastFrameFire = false;
 
   constructor(settings: Settings) {
     this.settings = settings;
     this.container = document.createElement('div');
     this.container.className = 'touch-container';
-    this.container.style.cssText = `position:fixed;inset:0;pointer-events:none;font-family:inherit;`;
+    this.container.style.cssText = 'position:fixed;inset:0;pointer-events:none;font-family:inherit;';
 
-    this.joystick = document.createElement('div');
-    this.joystick.className = 'touch-joystick';
-    this.joystickKnob = document.createElement('div');
-    this.joystickKnob.className = 'touch-joystick-knob';
-    this.joystick.appendChild(this.joystickKnob);
+    this.leftStick = document.createElement('div');
+    this.leftStick.id = 'joy-left';
 
-    this.lookPad = document.createElement('div');
-    this.lookPad.className = 'touch-lookpad';
+    this.rightStick = document.createElement('div');
+    this.rightStick.id = 'joy-right';
 
     this.rightControls = document.createElement('div');
     this.rightControls.className = 'touch-right-controls';
@@ -64,13 +61,21 @@ export class TouchControls {
     this.toggleButton = document.createElement('button');
     this.toggleButton.textContent = 'Touch Controls ON';
     this.toggleButton.className = 'touch-toggle';
-    this.toggleButton.style.cssText = `position:fixed;top:12px;left:12px;font-size:12px;opacity:0.5;z-index:20;`;
+    this.toggleButton.style.cssText = 'position:fixed;top:12px;left:12px;font-size:12px;opacity:0.5;z-index:20;';
+
+    this.debugReadout = document.createElement('div');
+    this.debugReadout.className = 'touch-debug';
+    this.debugReadout.style.cssText =
+      'position:fixed;bottom:12px;left:50%;transform:translateX(-50%);font-size:12px;color:#fff;pointer-events:none;opacity:0.75;text-shadow:0 1px 2px rgba(0,0,0,0.8);font-family:monospace;';
+    this.debugReadout.textContent = 'LX:0.00 LY:0.00 RX:0.00 RY:0.00';
+
     this.toggleButton.addEventListener('click', () => {
       this.setVisible(!this.visible);
       this.settings.touchEnabled = this.visible;
-      localStorage.setItem('raycast-retro-touch', JSON.stringify({ enabled: this.visible }));
+      localStorage.setItem('raycast-retro-touch', JSON.stringify({ enabled: this.visible } satisfies TouchPersist));
       this.updateToggleLabel();
     });
+
     if (this.isTouchDevice()) {
       this.toggleButton.style.display = 'none';
     }
@@ -78,7 +83,7 @@ export class TouchControls {
     const persisted = localStorage.getItem('raycast-retro-touch');
     if (persisted) {
       try {
-        const parsed = JSON.parse(persisted) as { enabled?: boolean };
+        const parsed = JSON.parse(persisted) as TouchPersist;
         if (typeof parsed.enabled === 'boolean') {
           this.settings.touchEnabled = parsed.enabled;
         }
@@ -87,14 +92,18 @@ export class TouchControls {
       }
     }
 
-    this.container.appendChild(this.joystick);
+    this.container.appendChild(this.leftStick);
     this.buttonCluster = document.createElement('div');
     this.buttonCluster.className = 'touch-buttons';
     this.buttonCluster.style.cssText = 'display:flex;flex-direction:column;gap:12px;pointer-events:auto;';
     const weaponRow = document.createElement('div');
     weaponRow.style.cssText = 'display:flex;gap:10px;';
+    const weaponIds: InputState['weaponSlot'][] = ['punch', 'pistol', 'knife'];
     this.weaponButtons.forEach((btn, idx) => {
-      btn.dataset.weapon = ['punch', 'pistol', 'knife'][idx]!;
+      const weaponId = weaponIds[idx];
+      if (weaponId) {
+        btn.dataset.weapon = weaponId;
+      }
       btn.addEventListener('pointerdown', (e) => {
         e.preventDefault();
         this.weaponQueued = btn.dataset.weapon as InputState['weaponSlot'];
@@ -109,17 +118,21 @@ export class TouchControls {
     this.buttonCluster.appendChild(actionRow);
     this.buttonCluster.appendChild(this.pauseButton);
 
-    this.rightControls.appendChild(this.lookPad);
+    this.rightControls.appendChild(this.rightStick);
     this.rightControls.appendChild(this.buttonCluster);
     this.container.appendChild(this.rightControls);
 
     document.body.appendChild(this.container);
     document.body.appendChild(this.toggleButton);
+    document.body.appendChild(this.debugReadout);
+
+    initVirtualJoysticks({ leftEl: this.leftStick, rightEl: this.rightStick });
+
     this.setVisible(this.settings.touchEnabled || this.isTouchDevice());
     this.updateToggleLabel();
     this.applyStyles();
     this.attachPointerListeners();
-    this.updateJoystickVisual();
+    this.updateDebugReadout({ x: 0, y: 0 }, { x: 0, y: 0 });
   }
 
   private isTouchDevice() {
@@ -135,7 +148,8 @@ export class TouchControls {
     btn.textContent = label;
     btn.type = 'button';
     btn.className = 'touch-button';
-    btn.style.cssText = 'width:72px;height:72px;border-radius:50%;border:none;background:rgba(255,255,255,0.65);color:#111;font-weight:bold;pointer-events:auto;touch-action:none;';
+    btn.style.cssText =
+      'width:72px;height:72px;border-radius:50%;border:none;background:rgba(255,255,255,0.65);color:#111;font-weight:bold;pointer-events:auto;touch-action:none;';
     btn.addEventListener('pointerdown', (e) => {
       e.preventDefault();
       btn.setAttribute('data-active', '1');
@@ -151,136 +165,92 @@ export class TouchControls {
 
   private attachPointerListeners() {
     const pointerOptions = { passive: false } as AddEventListenerOptions;
-    this.joystick.addEventListener('pointerdown', (e) => this.beginMove(e), pointerOptions);
-    this.lookPad.addEventListener('pointerdown', (e) => this.beginLook(e), pointerOptions);
-    window.addEventListener('pointermove', (e) => this.onPointerMove(e), pointerOptions);
-    window.addEventListener('pointerup', (e) => this.endPointer(e));
-    window.addEventListener('pointercancel', (e) => this.endPointer(e));
 
-    this.fireButton.addEventListener('pointerdown', (e) => {
-      e.preventDefault();
-      this.fireHeld = true;
-    });
+    this.fireButton.addEventListener(
+      'pointerdown',
+      (e) => {
+        e.preventDefault();
+        this.fireHeld = true;
+      },
+      pointerOptions
+    );
     this.fireButton.addEventListener('pointerup', () => (this.fireHeld = false));
     this.fireButton.addEventListener('pointercancel', () => (this.fireHeld = false));
 
-    this.interactButton.addEventListener('pointerdown', (e) => {
-      e.preventDefault();
-      this.interactHeld = true;
-    });
+    this.interactButton.addEventListener(
+      'pointerdown',
+      (e) => {
+        e.preventDefault();
+        this.interactHeld = true;
+      },
+      pointerOptions
+    );
     this.interactButton.addEventListener('pointerup', () => (this.interactHeld = false));
     this.interactButton.addEventListener('pointercancel', () => (this.interactHeld = false));
 
-    this.pauseButton.addEventListener('pointerdown', (e) => {
-      e.preventDefault();
-      this.pausedRequested = true;
-    });
-  }
-
-  private beginMove(e: PointerEvent) {
-    if (this.movePointer) return;
-    this.movePointer = {
-      id: e.pointerId,
-      startX: e.clientX,
-      startY: e.clientY,
-      currentX: e.clientX,
-      currentY: e.clientY,
-      active: true
-    };
-    this.updateJoystickVisual();
-    this.joystick.setPointerCapture(e.pointerId);
-  }
-
-  private beginLook(e: PointerEvent) {
-    if (this.lookPointer) return;
-    this.lookPointer = {
-      id: e.pointerId,
-      startX: e.clientX,
-      startY: e.clientY,
-      currentX: e.clientX,
-      currentY: e.clientY,
-      active: true
-    };
-    this.lookPad.setPointerCapture(e.pointerId);
-  }
-
-  private onPointerMove(e: PointerEvent) {
-    if (this.movePointer && this.movePointer.id === e.pointerId) {
-      this.movePointer.currentX = e.clientX;
-      this.movePointer.currentY = e.clientY;
-      this.updateJoystickVisual();
-    }
-    if (this.lookPointer && this.lookPointer.id === e.pointerId) {
-      const dx = e.clientX - this.lookPointer.currentX;
-      this.lookPointer.currentX = e.clientX;
-      this.lookPointer.currentY = e.clientY;
-      this.lookDelta += dx;
-    }
-  }
-
-  private endPointer(e: PointerEvent) {
-    if (this.movePointer && this.movePointer.id === e.pointerId) {
-      this.joystick.releasePointerCapture(e.pointerId);
-      this.movePointer = null;
-      this.updateJoystickVisual();
-    }
-    if (this.lookPointer && this.lookPointer.id === e.pointerId) {
-      this.lookPad.releasePointerCapture(e.pointerId);
-      this.lookPointer = null;
-    }
-    if (this.fireHeld && e.target === this.fireButton) {
-      this.fireHeld = false;
-    }
-    if (this.interactHeld && e.target === this.interactButton) {
-      this.interactHeld = false;
-    }
-  }
-
-  private updateJoystickVisual() {
-    const size = this.settings.joystickSize;
-    this.joystick.style.width = `${size}px`;
-    this.joystick.style.height = `${size}px`;
-    const knobSize = size * 0.4;
-    const move = this.getMoveVector();
-    const radius = (size - knobSize) / 2;
-    const offsetX = move.x * radius;
-    const offsetY = move.y * radius;
-    this.joystickKnob.style.width = `${knobSize}px`;
-    this.joystickKnob.style.height = `${knobSize}px`;
-    this.joystickKnob.style.transform = `translate(-50%, -50%) translate(${offsetX}px, ${offsetY}px)`;
+    this.pauseButton.addEventListener(
+      'pointerdown',
+      (e) => {
+        e.preventDefault();
+        this.pausedRequested = true;
+      },
+      pointerOptions
+    );
   }
 
   private applyStyles() {
     const baseOpacity = this.settings.uiOpacity;
+    const joystickSize = this.settings.joystickSize;
     const joystickSide = this.settings.leftHanded ? 'right' : 'left';
     const joystickOppositeSide = this.settings.leftHanded ? 'left' : 'right';
-    this.joystick.style.cssText = `position:absolute;bottom:20%;${joystickSide}:6%;${joystickOppositeSide}:auto;pointer-events:auto;border-radius:50%;background:rgba(40,40,60,${baseOpacity});backdrop-filter:blur(6px);touch-action:none;display:flex;align-items:center;justify-content:center;`;
-    this.joystickKnob.style.cssText =
-      'position:absolute;top:50%;left:50%;transform:translate(-50%, -50%);background:rgba(255,255,255,0.7);border-radius:50%;transition:background 0.1s;';
-    const lookPadSize = this.settings.joystickSize * 1.1;
-    this.lookPad.style.cssText = `width:${lookPadSize}px;height:${lookPadSize}px;border-radius:18px;background:rgba(40,40,60,${baseOpacity});pointer-events:auto;touch-action:none;`;
+
+    const stickStyle =
+      `position:absolute;bottom:18%;${joystickSide}:6%;${joystickOppositeSide}:auto;width:${joystickSize}px;height:${joystickSize}px;` +
+      `pointer-events:auto;border-radius:50%;background:rgba(40,40,60,${baseOpacity});backdrop-filter:blur(6px);outline:1px solid rgba(255,255,255,${baseOpacity * 0.3});display:flex;align-items:center;justify-content:center;`;
+    this.leftStick.style.cssText = stickStyle;
+
+    const rightStickSize = joystickSize * 1.05;
     const controlsSide = this.settings.leftHanded ? 'left' : 'right';
     const controlsOppositeSide = this.settings.leftHanded ? 'right' : 'left';
     const alignItems = this.settings.leftHanded ? 'flex-start' : 'flex-end';
-    this.rightControls.style.cssText = `position:absolute;bottom:18%;${controlsSide}:4%;${controlsOppositeSide}:auto;display:flex;flex-direction:column;align-items:${alignItems};gap:18px;pointer-events:auto;`;
+
+    this.rightStick.style.cssText =
+      `width:${rightStickSize}px;height:${rightStickSize}px;border-radius:18px;background:rgba(40,40,60,${baseOpacity});pointer-events:auto;touch-action:none;position:relative;`;
+
+    this.rightControls.style.cssText =
+      `position:absolute;bottom:16%;${controlsSide}:4%;${controlsOppositeSide}:auto;display:flex;flex-direction:column;align-items:${alignItems};gap:18px;pointer-events:auto;`;
+
     this.buttonCluster.style.alignItems = alignItems;
     this.fireButton.style.background = `rgba(255,120,80,${baseOpacity + 0.2})`;
     this.interactButton.style.background = `rgba(120,200,255,${baseOpacity + 0.2})`;
-    this.pauseButton.style.cssText = 'width:64px;height:64px;border-radius:18px;border:none;background:rgba(255,255,255,0.6);font-weight:bold;';
+    this.pauseButton.style.cssText =
+      'width:64px;height:64px;border-radius:18px;border:none;background:rgba(255,255,255,0.6);font-weight:bold;touch-action:none;';
     this.pauseButton.style.opacity = `${baseOpacity + 0.1}`;
     this.pauseButton.style.marginTop = '4px';
     this.pauseButton.style.alignSelf = 'flex-end';
-    this.container.style.setProperty('--touch-opacity', `${baseOpacity}`);
-    if (this.visible) {
-      document.body.style.touchAction = 'none';
-    } else {
-      document.body.style.touchAction = '';
+
+    document.body.style.touchAction = this.visible ? 'none' : '';
+
+    const leftNub = this.leftStick.querySelector('.nub') as HTMLDivElement | null;
+    const rightNub = this.rightStick.querySelector('.nub') as HTMLDivElement | null;
+    const leftNubSize = joystickSize * 0.35;
+    const rightNubSize = rightStickSize * 0.22;
+    if (leftNub) {
+      leftNub.style.cssText =
+        `position:absolute;top:50%;left:50%;width:${leftNubSize}px;height:${leftNubSize}px;border-radius:50%;transform:translate(-50%, -50%);` +
+        `background:rgba(255,255,255,0.18);box-shadow:0 2px 6px rgba(0,0,0,0.4);transition:background 0.1s;`;
+    }
+    if (rightNub) {
+      rightNub.style.cssText =
+        `position:absolute;top:50%;left:50%;width:${rightNubSize}px;height:${rightNubSize}px;border-radius:50%;transform:translate(-50%, -50%);` +
+        `background:rgba(255,255,255,0.18);box-shadow:0 2px 6px rgba(0,0,0,0.4);transition:background 0.1s;`;
     }
   }
 
   setVisible(visible: boolean) {
     this.visible = visible;
     this.container.style.display = visible ? 'block' : 'none';
+    this.debugReadout.style.display = visible ? 'block' : 'none';
     if (!visible) {
       this.resetState();
     }
@@ -291,48 +261,53 @@ export class TouchControls {
     this.settings = settings;
     this.setVisible(settings.touchEnabled || this.visible);
     this.applyStyles();
-    this.updateJoystickVisual();
+    this.updateToggleLabel();
   }
 
   private resetState() {
-    this.movePointer = null;
-    this.lookPointer = null;
-    this.lookDelta = 0;
     this.fireHeld = false;
     this.interactHeld = false;
     this.weaponQueued = null;
+    this.pausedRequested = false;
+    resetVirtualJoysticks();
   }
 
-  private getMoveVector(): Vec2 {
-    if (!this.movePointer) return { x: 0, y: 0 };
-    const dx = this.movePointer.currentX - this.movePointer.startX;
-    const dy = this.movePointer.currentY - this.movePointer.startY;
-    const radius = this.settings.joystickSize * 0.5;
-    const nx = clamp(dx / radius, -1, 1);
-    const ny = clamp(dy / radius, -1, 1);
-    const mag = length({ x: nx, y: ny });
-    if (mag < DEADZONE) return { x: 0, y: 0 };
-    const scale = Math.min(1, mag);
-    return { x: nx * scale, y: ny * scale };
+  private updateDebugReadout(left = getLeftVector(), right = getRightVector()) {
+    this.debugReadout.textContent = `${formatStickValue('LX', left.x)} ${formatStickValue('LY', left.y)} ${formatStickValue('RX', right.x)} ${formatStickValue('RY', right.y)}`;
   }
 
   getState(): Partial<InputState> {
     if (!this.visible) {
-      return { forward: 0, strafe: 0, turning: 0, fire: false, interact: false };
+      this.updateDebugReadout({ x: 0, y: 0 }, { x: 0, y: 0 });
+      return { forward: 0, strafe: 0, turning: 0, looking: 0, fire: false, interact: false };
     }
-    const move = this.getMoveVector();
-    const forward = -move.y;
-    const turningFromMove = this.lookPointer ? 0 : clamp(move.x * 0.24, -0.35, 0.35);
-    const strafe = this.lookPointer ? move.x : 0;
-    const turningFromLookPad = clamp(this.lookDelta * 0.003, -0.45, 0.45);
-    const turning = clamp(turningFromMove + turningFromLookPad, -0.45, 0.45);
+
+    const left = getLeftVector();
+    const rightRaw = getRightVector();
+    const right = { x: rightRaw.x, y: invertLookY ? -rightRaw.y : rightRaw.y };
+
+    const forward = clamp(-left.y, -1, 1);
+    const strafe = clamp(left.x, -1, 1);
+
+    const lookScale = this.settings.lookSensitivity * 600 || 1;
+    const turnMultiplier = turnSpeed / lookScale;
+    const turning = clamp(right.x * turnMultiplier, -turnMultiplier, turnMultiplier);
+
+    const looking = clamp(-right.y * pitchSpeed, -pitchSpeed, pitchSpeed);
+
     const fire = this.fireHeld;
     const interact = this.interactHeld;
     const weaponSlot = this.weaponQueued;
     this.weaponQueued = null;
+
     const pauseRequested = this.pausedRequested;
     this.pausedRequested = false;
-    this.lookDelta = 0;
-    return { forward, strafe, turning, fire, interact, weaponSlot, pauseRequested };
+    if (pauseRequested) {
+      resetVirtualJoysticks();
+    }
+
+    this.updateDebugReadout(left, rightRaw);
+
+    return { forward, strafe, turning, looking, fire, interact, weaponSlot, pauseRequested };
   }
 }


### PR DESCRIPTION
## Summary
- add configurable touch control constants including deadzone, speed, and invert look toggle
- implement a reusable virtual joystick helper with deadzone, smoothing, and pause reset behaviour
- refactor touch controls to use the joysticks for movement/view mapping, add debug readout, and prevent page scrolling while active

## Testing
- python -m http.server 4173 (manual smoke test / screenshot capture)


------
https://chatgpt.com/codex/tasks/task_e_68d742b8010c8333a43692296ad265f9