### PR TITLE
Align touch turning rate with keyboard range

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -35,7 +35,7 @@ export const config = {
   moveSpeed: 3.5,
   strafeSpeed: 3,
   runSpeedMultiplier: 1.4,
-  turnSpeed: 2.5,
+  turnSpeed: 0.3,
   fov: (70 * Math.PI) / 180,
   maxRenderDistance: 20,
   floorColor: '#1e1b2f',

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,7 +37,7 @@ export const config = {
   moveSpeed: 3.5,
   strafeSpeed: 3,
   runSpeedMultiplier: 1.4,
-  turnSpeed: 2.5,
+  turnSpeed: 0.3,
   fov: (70 * Math.PI) / 180,
   maxRenderDistance: 20,
   floorColor: '#1e1b2f',

--- a/src/touch.js
+++ b/src/touch.js
@@ -307,16 +307,30 @@ export class TouchControls {
     return { x: nx * scale, y: ny * scale };
   }
 
+  getLookAxis() {
+    if (!this.lookPointer) return 0;
+    const lookPadSize = this.settings.joystickSize * 1.1;
+    const radius = Math.max(lookPadSize / 2, 1);
+    const dx = this.lookPointer.currentX - this.lookPointer.startX;
+    const normalized = clamp(dx / radius, -1, 1);
+    if (Math.abs(normalized) < DEADZONE) {
+      return 0;
+    }
+    return normalized;
+  }
+
   getState() {
     if (!this.visible) {
       return { forward: 0, strafe: 0, turning: 0, fire: false, interact: false };
     }
     const move = this.getMoveVector();
     const forward = -move.y;
-    const turningFromMove = this.lookPointer ? 0 : clamp(move.x * 0.24, -0.35, 0.35);
+    const turningFromMove = this.lookPointer ? 0 : clamp(move.x * 0.24, -0.3, 0.3);
     const strafe = this.lookPointer ? move.x : 0;
-    const turningFromLookPad = clamp(this.lookDelta * 0.003, -0.45, 0.45);
-    const turning = clamp(turningFromMove + turningFromLookPad, -0.45, 0.45);
+    const stickTurn = clamp(this.getLookAxis() * 0.3, -0.3, 0.3);
+    const swipeTurn = clamp(this.lookDelta * 0.003, -0.3, 0.3);
+    const turningFromLookPad = clamp(stickTurn + swipeTurn, -0.3, 0.3);
+    const turning = clamp(turningFromMove + turningFromLookPad, -0.3, 0.3);
     const fire = this.fireHeld;
     const interact = this.interactHeld;
     const weaponSlot = this.weaponQueued;

--- a/src/touch.ts
+++ b/src/touch.ts
@@ -316,16 +316,30 @@ export class TouchControls {
     return { x: nx * scale, y: ny * scale };
   }
 
+  private getLookAxis(): number {
+    if (!this.lookPointer) return 0;
+    const lookPadSize = this.settings.joystickSize * 1.1;
+    const radius = Math.max(lookPadSize / 2, 1);
+    const dx = this.lookPointer.currentX - this.lookPointer.startX;
+    const normalized = clamp(dx / radius, -1, 1);
+    if (Math.abs(normalized) < DEADZONE) {
+      return 0;
+    }
+    return normalized;
+  }
+
   getState(): Partial<InputState> {
     if (!this.visible) {
       return { forward: 0, strafe: 0, turning: 0, fire: false, interact: false };
     }
     const move = this.getMoveVector();
     const forward = -move.y;
-    const turningFromMove = this.lookPointer ? 0 : clamp(move.x * 0.24, -0.35, 0.35);
+    const turningFromMove = this.lookPointer ? 0 : clamp(move.x * 0.24, -0.3, 0.3);
     const strafe = this.lookPointer ? move.x : 0;
-    const turningFromLookPad = clamp(this.lookDelta * 0.003, -0.45, 0.45);
-    const turning = clamp(turningFromMove + turningFromLookPad, -0.45, 0.45);
+    const stickTurn = clamp(this.getLookAxis() * 0.3, -0.3, 0.3);
+    const swipeTurn = clamp(this.lookDelta * 0.003, -0.3, 0.3);
+    const turningFromLookPad = clamp(stickTurn + swipeTurn, -0.3, 0.3);
+    const turning = clamp(turningFromMove + turningFromLookPad, -0.3, 0.3);
     const fire = this.fireHeld;
     const interact = this.interactHeld;
     const weaponSlot = this.weaponQueued;


### PR DESCRIPTION
## Summary
- normalize the touch look pad X axis so the resulting turning matches the ±0.3 keyboard/mouse range
- clamp the combined touch turning contribution to the same range for consistent yaw speed
- update the turnSpeed control config default to reflect the intended pointer-delta range

## Testing
- npm run build *(fails: Missing script "build")*

------
https://chatgpt.com/codex/tasks/task_e_68d74674ae2483339e3f73abf0ddfb77