### PR TITLE
Enable strafing from the touch joystick without look input

### DIFF
--- a/src/touch.js
+++ b/src/touch.js
@@ -313,10 +313,8 @@ export class TouchControls {
     }
     const move = this.getMoveVector();
     const forward = -move.y;
-    const turningFromMove = this.lookPointer ? 0 : clamp(move.x * 0.24, -0.35, 0.35);
-    const strafe = this.lookPointer ? move.x : 0;
-    const turningFromLookPad = clamp(this.lookDelta * 0.003, -0.45, 0.45);
-    const turning = clamp(turningFromMove + turningFromLookPad, -0.45, 0.45);
+    const strafe = move.x;
+    const turning = clamp(this.lookDelta * 0.003, -0.45, 0.45);
     const fire = this.fireHeld;
     const interact = this.interactHeld;
     const weaponSlot = this.weaponQueued;

--- a/src/touch.ts
+++ b/src/touch.ts
@@ -322,10 +322,8 @@ export class TouchControls {
     }
     const move = this.getMoveVector();
     const forward = -move.y;
-    const turningFromMove = this.lookPointer ? 0 : clamp(move.x * 0.24, -0.35, 0.35);
-    const strafe = this.lookPointer ? move.x : 0;
-    const turningFromLookPad = clamp(this.lookDelta * 0.003, -0.45, 0.45);
-    const turning = clamp(turningFromMove + turningFromLookPad, -0.45, 0.45);
+    const strafe = move.x;
+    const turning = clamp(this.lookDelta * 0.003, -0.45, 0.45);
     const fire = this.fireHeld;
     const interact = this.interactHeld;
     const weaponSlot = this.weaponQueued;


### PR DESCRIPTION
## Summary
- allow the touch movement joystick to always provide horizontal strafing
- rely on the look pad for turning input instead of the movement joystick

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d748f6867883338bf757dd9529e2ff