### PR TITLE
Fix touch joystick strafe direction

### DIFF
--- a/src/touch.js
+++ b/src/touch.js
@@ -313,7 +313,7 @@ export class TouchControls {
     }
     const move = this.getMoveVector();
     const forward = -move.y;
-    const strafe = move.x;
+    const strafe = -move.x;
     const turning = clamp(this.lookDelta * 0.003, -0.45, 0.45);
     const fire = this.fireHeld;
     const interact = this.interactHeld;

--- a/src/touch.ts
+++ b/src/touch.ts
@@ -322,7 +322,7 @@ export class TouchControls {
     }
     const move = this.getMoveVector();
     const forward = -move.y;
-    const strafe = move.x;
+    const strafe = -move.x;
     const turning = clamp(this.lookDelta * 0.003, -0.45, 0.45);
     const fire = this.fireHeld;
     const interact = this.interactHeld;


### PR DESCRIPTION
## Summary
- invert the touch joystick's horizontal output so moving left strafes left as expected
- keep the JavaScript build artifact in sync with the TypeScript source

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d74bf01208833389e3dda6a32c9c63