### PR TITLE
Add minimap overlay enhancements and safer pickup spawning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "raycast-retro",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "raycast-retro",
+      "version": "0.1.0"
+    }
+  }
+}

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -54,6 +54,18 @@ function renderMinimap(
 
   const playerX = originX + player.position.x * tileWidth;
   const playerY = originY + player.position.y * tileHeight;
+  ctx.fillStyle = 'rgba(242, 201, 76, 0.12)';
+  ctx.beginPath();
+  ctx.moveTo(playerX, playerY);
+  const fovReach = 5;
+  const leftEdgeX = player.direction.x - player.plane.x;
+  const leftEdgeY = player.direction.y - player.plane.y;
+  const rightEdgeX = player.direction.x + player.plane.x;
+  const rightEdgeY = player.direction.y + player.plane.y;
+  ctx.lineTo(playerX + rightEdgeX * fovReach * tileWidth, playerY + rightEdgeY * fovReach * tileHeight);
+  ctx.lineTo(playerX + leftEdgeX * fovReach * tileWidth, playerY + leftEdgeY * fovReach * tileHeight);
+  ctx.closePath();
+  ctx.fill();
   ctx.fillStyle = '#ffffff';
   ctx.beginPath();
   ctx.arc(playerX, playerY, 4, 0, Math.PI * 2);

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import { createEnemy, updateEnemies } from './enemy';
 import { createPickup, tryCollect } from './pickups';
 import type { EnemyInstance, PickupInstance, Settings, SpriteRenderable } from './types';
 import { UIManager } from './ui';
+import { findNearestWalkablePoint } from './spawn';
 
 function injectStyles() {
   const style = document.createElement('style');
@@ -109,7 +110,7 @@ async function bootstrap() {
         amount: item.type === 'health' ? 25 : item.type === 'armor' ? 20 : 12,
         sprite: assets.pickups[item.type]
       },
-      item.position,
+      findNearestWalkablePoint(level1, item.position),
       index
     )
   );
@@ -214,10 +215,10 @@ async function bootstrap() {
         image: pickup.definition.sprite,
         position: pickup.position,
         size: 0.7,
-        offsetY: 20,
         isBillboard: true,
         distance: 0,
-        type: 'pickup'
+        type: 'pickup',
+        anchor: 'floor'
       });
     }
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -83,10 +83,23 @@ export class Renderer {
 
       const spriteScreenX = Math.floor((width / 2) * (1 + transformX / transformY));
       const spriteHeight = Math.abs(Math.floor(height / transformY)) * sprite.size;
-      let drawStartY = -spriteHeight / 2 + height / 2 + (sprite.offsetY ?? 0);
-      let drawEndY = spriteHeight / 2 + height / 2 + (sprite.offsetY ?? 0);
+      const offsetY = sprite.offsetY ?? 0;
+      const anchor = sprite.anchor ?? 'center';
+      let drawStartY: number;
+      let drawEndY: number;
+
+      if (anchor === 'floor') {
+        const floorLine = Math.min(height, height / 2 + offsetY);
+        drawEndY = floorLine;
+        drawStartY = floorLine - spriteHeight;
+      } else {
+        drawStartY = -spriteHeight / 2 + height / 2 + offsetY;
+        drawEndY = spriteHeight / 2 + height / 2 + offsetY;
+      }
+
       if (drawStartY < 0) drawStartY = 0;
       if (drawEndY >= height) drawEndY = height;
+      if (drawEndY <= drawStartY) continue;
 
       const spriteWidth = Math.abs(Math.floor(height / transformY));
       let drawStartX = -spriteWidth / 2 + spriteScreenX;

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -1,0 +1,51 @@
+import type { LevelDefinition, Vec2 } from './types';
+
+function isWallTile(level: LevelDefinition, tileX: number, tileY: number): boolean {
+  if (tileX < 0 || tileY < 0 || tileX >= level.width || tileY >= level.height) {
+    return true;
+  }
+  return level.tiles[tileY * level.width + tileX] > 0;
+}
+
+export function findNearestWalkablePoint(level: LevelDefinition, target: Vec2): Vec2 {
+  const startTileX = Math.floor(target.x);
+  const startTileY = Math.floor(target.y);
+  const queue: { x: number; y: number }[] = [{ x: startTileX, y: startTileY }];
+  const visited = new Set<string>();
+
+  const directions = [
+    { x: 1, y: 0 },
+    { x: -1, y: 0 },
+    { x: 0, y: 1 },
+    { x: 0, y: -1 },
+    { x: 1, y: 1 },
+    { x: 1, y: -1 },
+    { x: -1, y: 1 },
+    { x: -1, y: -1 }
+  ];
+
+  while (queue.length > 0) {
+    const { x, y } = queue.shift()!;
+    const key = `${x},${y}`;
+    if (visited.has(key)) continue;
+    visited.add(key);
+
+    if (!isWallTile(level, x, y)) {
+      return { x: x + 0.5, y: y + 0.5 };
+    }
+
+    for (const dir of directions) {
+      const nextX = x + dir.x;
+      const nextY = y + dir.y;
+      const nextKey = `${nextX},${nextY}`;
+      if (!visited.has(nextKey)) {
+        queue.push({ x: nextX, y: nextY });
+      }
+    }
+  }
+
+  return {
+    x: Math.min(Math.max(target.x, 0.5), level.width - 0.5),
+    y: Math.min(Math.max(target.y, 0.5), level.height - 0.5)
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,6 +110,7 @@ export interface SpriteRenderable {
   distance: number;
   type: 'enemy' | 'pickup';
   id: number;
+  anchor?: 'center' | 'floor';
 }
 
 export interface Settings {


### PR DESCRIPTION
## Summary
- enhance the HUD minimap with a field-of-view cone so navigation is clearer
- ensure pickups snap to the nearest walkable floor tile and render anchored to the ground

## Testing
- `npm run build` *(fails: Missing script "build")*

------
https://chatgpt.com/codex/tasks/task_e_68d81bc30b1483338464e8f87240c391