### PR TITLE
Add HUD minimap overlay

### DIFF
--- a/src/hud.js
+++ b/src/hud.js
@@ -1,6 +1,63 @@
 import { config } from './config.js';
 
-export function renderHUD(ctx, canvas, player, weapon, hud, settings) {
+function renderMinimap(ctx, canvas, level, player, sprites, settings) {
+  const size = 180;
+  const padding = 24;
+  const tileWidth = size / level.width;
+  const tileHeight = size / level.height;
+  const originX = canvas.width - padding - size;
+  const originY = padding;
+
+  ctx.save();
+  ctx.globalAlpha = Math.min(1, Math.max(0.35, settings.uiOpacity + 0.2));
+  ctx.fillStyle = 'rgba(8, 6, 18, 0.9)';
+  ctx.fillRect(originX - 6, originY - 6, size + 12, size + 12);
+  ctx.strokeStyle = 'rgba(255, 255, 255, 0.25)';
+  ctx.lineWidth = 2;
+  ctx.strokeRect(originX - 6, originY - 6, size + 12, size + 12);
+  ctx.fillStyle = 'rgba(12, 10, 26, 0.9)';
+  ctx.fillRect(originX, originY, size, size);
+
+  ctx.globalAlpha = 1;
+  ctx.fillStyle = '#2d3359';
+  for (let y = 0; y < level.height; y++) {
+    for (let x = 0; x < level.width; x++) {
+      const tile = level.tiles[y * level.width + x];
+      if (tile <= 0) continue;
+      ctx.fillRect(originX + x * tileWidth, originY + y * tileHeight, tileWidth, tileHeight);
+    }
+  }
+
+  for (const sprite of sprites) {
+    const spriteX = originX + sprite.position.x * tileWidth;
+    const spriteY = originY + sprite.position.y * tileHeight;
+    ctx.fillStyle = sprite.type === 'enemy' ? '#ff6b6b' : '#f2c94c';
+    ctx.beginPath();
+    ctx.arc(spriteX, spriteY, sprite.type === 'enemy' ? 3 : 2, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  const playerX = originX + player.position.x * tileWidth;
+  const playerY = originY + player.position.y * tileHeight;
+  ctx.fillStyle = '#ffffff';
+  ctx.beginPath();
+  ctx.arc(playerX, playerY, 4, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.strokeStyle = '#ffffff';
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(playerX, playerY);
+  ctx.lineTo(playerX + player.direction.x * 14, playerY + player.direction.y * 14);
+  ctx.stroke();
+
+  ctx.restore();
+}
+
+export function renderHUD(ctx, canvas, player, weapon, hud, settings, level, sprites) {
+  if (level) {
+    renderMinimap(ctx, canvas, level, player, sprites, settings);
+  }
+
   const hudHeight = config.hudHeight;
   ctx.save();
   ctx.fillStyle = 'rgba(15, 10, 25, 0.85)';

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -108,6 +108,6 @@ export class Renderer {
 
     this.ctx.imageSmoothingEnabled = false;
     this.ctx.drawImage(this.view, 0, 0, this.canvas.width, this.canvas.height);
-    renderHUD(this.ctx, this.canvas, player, weapon, hud, settings);
+    renderHUD(this.ctx, this.canvas, player, weapon, hud, settings, raycaster.level, sprites);
   }
 }


### PR DESCRIPTION
## Summary
- draw a minimap overlay within the HUD, including rooms, enemies, pickups, and player direction
- pass level geometry and sprite data to the HUD renderer so the overlay stays in sync with gameplay

## Testing
- python -m http.server 4173


------
https://chatgpt.com/codex/tasks/task_e_68d81dd1e2e48333b8a6aeca6ee52fdc