### PR TITLE
Prevent spawns from appearing inside walls

### DIFF
--- a/src/collisions.js
+++ b/src/collisions.js
@@ -1,12 +1,12 @@
-import { config } from './config.js';
+const DEFAULT_RADIUS = 0.3;
 
 export function resolveMovement(position, velocity, delta, level) {
-  const radius = 0.3;
+  const radius = DEFAULT_RADIUS;
   const nextX = position.x + velocity.x * delta;
   const nextY = position.y + velocity.y * delta;
 
-  const canMoveX = !isWall(nextX, position.y, level, radius);
-  const canMoveY = !isWall(position.x, nextY, level, radius);
+  const canMoveX = !isPositionBlocked(nextX, position.y, level, radius);
+  const canMoveY = !isPositionBlocked(position.x, nextY, level, radius);
 
   return {
     x: canMoveX ? nextX : position.x,
@@ -14,7 +14,7 @@ export function resolveMovement(position, velocity, delta, level) {
   };
 }
 
-function isWall(x, y, level, radius) {
+export function isPositionBlocked(x, y, level, radius = DEFAULT_RADIUS) {
   const minX = Math.floor(x - radius);
   const maxX = Math.floor(x + radius);
   const minY = Math.floor(y - radius);
@@ -27,4 +27,56 @@ function isWall(x, y, level, radius) {
     }
   }
   return false;
+}
+
+export function findNearestOpenPosition(target, level, radius = DEFAULT_RADIUS) {
+  if (!isPositionBlocked(target.x, target.y, level, radius)) {
+    return { ...target };
+  }
+
+  const startTileX = Math.floor(target.x);
+  const startTileY = Math.floor(target.y);
+  const visited = new Set();
+  const queue = [{ x: startTileX, y: startTileY }];
+  const directions = [
+    [1, 0],
+    [-1, 0],
+    [0, 1],
+    [0, -1],
+    [1, 1],
+    [1, -1],
+    [-1, 1],
+    [-1, -1]
+  ];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    const key = `${current.x},${current.y}`;
+    if (visited.has(key)) {
+      continue;
+    }
+    visited.add(key);
+
+    if (current.x < 0 || current.y < 0 || current.x >= level.width || current.y >= level.height) {
+      continue;
+    }
+
+    const tileValue = level.tiles[current.y * level.width + current.x];
+    if (tileValue === 0) {
+      const center = { x: current.x + 0.5, y: current.y + 0.5 };
+      if (!isPositionBlocked(center.x, center.y, level, radius)) {
+        return center;
+      }
+    }
+
+    for (const [dx, dy] of directions) {
+      const next = { x: current.x + dx, y: current.y + dy };
+      const nextKey = `${next.x},${next.y}`;
+      if (!visited.has(nextKey)) {
+        queue.push(next);
+      }
+    }
+  }
+
+  return { ...target };
 }

--- a/src/collisions.ts
+++ b/src/collisions.ts
@@ -1,13 +1,14 @@
-import { config } from './config';
 import type { LevelDefinition, Vec2 } from './types';
 
+const DEFAULT_RADIUS = 0.3;
+
 export function resolveMovement(position: Vec2, velocity: Vec2, delta: number, level: LevelDefinition): Vec2 {
-  const radius = 0.3;
+  const radius = DEFAULT_RADIUS;
   const nextX = position.x + velocity.x * delta;
   const nextY = position.y + velocity.y * delta;
 
-  const canMoveX = !isWall(nextX, position.y, level, radius);
-  const canMoveY = !isWall(position.x, nextY, level, radius);
+  const canMoveX = !isPositionBlocked(nextX, position.y, level, radius);
+  const canMoveY = !isPositionBlocked(position.x, nextY, level, radius);
 
   return {
     x: canMoveX ? nextX : position.x,
@@ -15,7 +16,7 @@ export function resolveMovement(position: Vec2, velocity: Vec2, delta: number, l
   };
 }
 
-function isWall(x: number, y: number, level: LevelDefinition, radius: number) {
+export function isPositionBlocked(x: number, y: number, level: LevelDefinition, radius: number = DEFAULT_RADIUS) {
   const minX = Math.floor(x - radius);
   const maxX = Math.floor(x + radius);
   const minY = Math.floor(y - radius);
@@ -28,4 +29,56 @@ function isWall(x: number, y: number, level: LevelDefinition, radius: number) {
     }
   }
   return false;
+}
+
+export function findNearestOpenPosition(target: Vec2, level: LevelDefinition, radius: number = DEFAULT_RADIUS): Vec2 {
+  if (!isPositionBlocked(target.x, target.y, level, radius)) {
+    return { ...target };
+  }
+
+  const startTileX = Math.floor(target.x);
+  const startTileY = Math.floor(target.y);
+  const visited = new Set<string>();
+  const queue: { x: number; y: number }[] = [{ x: startTileX, y: startTileY }];
+  const directions = [
+    [1, 0],
+    [-1, 0],
+    [0, 1],
+    [0, -1],
+    [1, 1],
+    [1, -1],
+    [-1, 1],
+    [-1, -1]
+  ];
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    const key = `${current.x},${current.y}`;
+    if (visited.has(key)) {
+      continue;
+    }
+    visited.add(key);
+
+    if (current.x < 0 || current.y < 0 || current.x >= level.width || current.y >= level.height) {
+      continue;
+    }
+
+    const tileValue = level.tiles[current.y * level.width + current.x];
+    if (tileValue === 0) {
+      const center = { x: current.x + 0.5, y: current.y + 0.5 };
+      if (!isPositionBlocked(center.x, center.y, level, radius)) {
+        return center;
+      }
+    }
+
+    for (const [dx, dy] of directions) {
+      const next = { x: current.x + dx, y: current.y + dy };
+      const nextKey = `${next.x},${next.y}`;
+      if (!visited.has(nextKey)) {
+        queue.push(next);
+      }
+    }
+  }
+
+  return { ...target };
 }

--- a/src/main.js
+++ b/src/main.js
@@ -12,6 +12,7 @@ import { Raycaster } from './raycaster.js';
 import { createEnemy, updateEnemies } from './enemy.js';
 import { createPickup, tryCollect } from './pickups.js';
 import { UIManager } from './ui.js';
+import { findNearestOpenPosition } from './collisions.js';
 
 function injectStyles() {
   const style = document.createElement('style');
@@ -80,7 +81,8 @@ async function bootstrap() {
   const assets = await loadAssets();
   const weapons = createWeaponDefinitions(assets.weapons);
   const player = createPlayer(weapons);
-  setPlayerStart(player, level1.playerStart.x, level1.playerStart.y, 0);
+  const safePlayerStart = findNearestOpenPosition(level1.playerStart, level1);
+  setPlayerStart(player, safePlayerStart.x, safePlayerStart.y, 0);
   const raycaster = new Raycaster(level1);
   raycaster.setTextures(assets.textures);
 
@@ -95,7 +97,7 @@ async function bootstrap() {
         attackCooldown: 0.8,
         aggroRange: 8
       },
-      spawn.position,
+      findNearestOpenPosition(spawn.position, level1),
       index
     )
   );
@@ -108,7 +110,7 @@ async function bootstrap() {
         amount: item.type === 'health' ? 25 : item.type === 'armor' ? 20 : 12,
         sprite: assets.pickups[item.type]
       },
-      item.position,
+      findNearestOpenPosition(item.position, level1, 0.2),
       index
     )
   );

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import { createEnemy, updateEnemies } from './enemy';
 import { createPickup, tryCollect } from './pickups';
 import type { EnemyInstance, PickupInstance, Settings, SpriteRenderable } from './types';
 import { UIManager } from './ui';
+import { findNearestOpenPosition } from './collisions';
 
 function injectStyles() {
   const style = document.createElement('style');
@@ -81,7 +82,8 @@ async function bootstrap() {
   const assets = await loadAssets();
   const weapons = createWeaponDefinitions(assets.weapons);
   const player = createPlayer(weapons);
-  setPlayerStart(player, level1.playerStart.x, level1.playerStart.y, 0);
+  const safePlayerStart = findNearestOpenPosition(level1.playerStart, level1);
+  setPlayerStart(player, safePlayerStart.x, safePlayerStart.y, 0);
   const raycaster = new Raycaster(level1);
   raycaster.setTextures(assets.textures);
 
@@ -96,7 +98,7 @@ async function bootstrap() {
         attackCooldown: 0.8,
         aggroRange: 8
       },
-      spawn.position,
+      findNearestOpenPosition(spawn.position, level1),
       index
     )
   );
@@ -109,7 +111,7 @@ async function bootstrap() {
         amount: item.type === 'health' ? 25 : item.type === 'armor' ? 20 : 12,
         sprite: assets.pickups[item.type]
       },
-      item.position,
+      findNearestOpenPosition(item.position, level1, 0.2),
       index
     )
   );


### PR DESCRIPTION
## Summary
- add helpers to detect blocked tiles and find the nearest open spot
- ensure the player, enemies, and pickups spawn at safe positions instead of intersecting walls

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d821a27d788333add91dd973897e12