### PR TITLE
Ensure sprite stripes use integer indices

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -94,8 +94,12 @@ export class Renderer {
 
       if (drawStartX < 0) drawStartX = 0;
       if (drawEndX >= width) drawEndX = width;
+      drawStartX = Math.floor(drawStartX);
+      drawEndX = Math.ceil(drawEndX);
+      const startStripe = drawStartX;
+      const endStripe = drawEndX;
 
-      for (let stripe = drawStartX; stripe < drawEndX; stripe++) {
+      for (let stripe = startStripe; stripe < endStripe; stripe++) {
         const texX = Math.floor(((stripe - (-spriteWidth / 2 + spriteScreenX)) * sprite.image.width) / spriteWidth);
         if (transformY > 0 && stripe > 0 && stripe < width && transformY < this.depthBuffer[stripe]) {
           ctx.drawImage(


### PR DESCRIPTION
## Summary
- clamp sprite draw bounds to the screen and immediately round them to integer columns
- iterate sprite stripes using the rounded bounds so depth buffer access always uses integers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d824d79c048333a219525fd7a02008