### PR TITLE
Stabilize sprite depth comparisons

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -94,10 +94,17 @@ export class Renderer {
 
       if (drawStartX < 0) drawStartX = 0;
       if (drawEndX >= width) drawEndX = width;
+      drawStartX = Math.floor(drawStartX);
+      drawEndX = Math.ceil(drawEndX);
+      const startStripe = Math.max(0, drawStartX);
+      const endStripe = Math.min(width, drawEndX);
+      const depthEpsilon = 1e-4;
 
-      for (let stripe = drawStartX; stripe < drawEndX; stripe++) {
+      for (let stripe = startStripe; stripe < endStripe; stripe++) {
         const texX = Math.floor(((stripe - (-spriteWidth / 2 + spriteScreenX)) * sprite.image.width) / spriteWidth);
-        if (transformY > 0 && stripe > 0 && stripe < width && transformY < this.depthBuffer[stripe]) {
+        if (transformY > 0 && stripe >= 0 && stripe < width) {
+          const wallDepth = this.depthBuffer[stripe];
+          if (transformY - wallDepth > depthEpsilon) continue;
           ctx.drawImage(
             sprite.image,
             texX,


### PR DESCRIPTION
## Summary
- clamp sprite draw bounds to the screen and immediately round them to integer columns
- iterate sprite stripes using the rounded bounds so depth buffer access always uses integers
- relax sprite depth comparisons with a small epsilon so moving enemies no longer flicker when partially occluded

## Testing
- not run (build script missing)


------
https://chatgpt.com/codex/tasks/task_e_68d824d79c048333a219525fd7a02008