### PR TITLE
Fix sprite column indices to prevent flickering

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -89,8 +89,8 @@ export class Renderer {
       if (drawEndY >= height) drawEndY = height;
 
       const spriteWidth = Math.abs(Math.floor(height / transformY));
-      let drawStartX = -spriteWidth / 2 + spriteScreenX;
-      let drawEndX = spriteWidth / 2 + spriteScreenX;
+      let drawStartX = Math.floor(-spriteWidth / 2 + spriteScreenX);
+      let drawEndX = Math.ceil(spriteWidth / 2 + spriteScreenX);
 
       if (drawStartX < 0) drawStartX = 0;
       if (drawEndX >= width) drawEndX = width;


### PR DESCRIPTION
## Summary
- ensure sprite sprite column bounds are converted to integers before iterating so the depth buffer is accessed using whole-number indices

## Testing
- npm run build *(fails: Missing script "build")*

------
https://chatgpt.com/codex/tasks/task_e_68d8278231748333bb7bc49cba9342f5