### PR TITLE
Add hit markers and raycast-aware attacks

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ import { createPlayer, playerFire, setPlayerStart, updatePlayer, endAttack } fro
 import { createWeaponDefinitions, performAttack } from './weapons.js';
 import { level1 } from './level1.js';
 import { Raycaster } from './raycaster.js';
-import { createEnemy, updateEnemies } from './enemy.js';
+import { applyDamage, createEnemy, updateEnemies } from './enemy.js';
 import { createPickup, tryCollect } from './pickups.js';
 import { UIManager } from './ui.js';
 import { findNearestOpenPosition } from './collisions.js';
@@ -135,6 +135,7 @@ async function bootstrap() {
   let lastAttackTime = 0;
   let hudState = { fps: 60, showDebug: false, messages: [] };
   let lastRender = performance.now();
+  const hitMarkers = [];
 
   const loop = new GameLoop((delta, time) => {
     if (paused) return;
@@ -165,10 +166,39 @@ async function bootstrap() {
     updatePlayer(player, combined, delta, settings, level1);
     updateEnemies(enemies, delta, level1, player);
 
+    for (let i = hitMarkers.length - 1; i >= 0; i--) {
+      const marker = hitMarkers[i];
+      marker.timer -= delta;
+      if (marker.timer <= 0) {
+        hitMarkers.splice(i, 1);
+      }
+    }
+
     if (combined.fire && time - lastAttackTime > 0.05) {
       const weapon = playerFire(player, time);
       if (weapon) {
-        performAttack(weapon, player, enemies);
+        const attack = performAttack(weapon, player, enemies, raycaster);
+        if (attack.enemy) {
+          applyDamage(attack.enemy, weapon.damage);
+        }
+
+        const clampedDistance = Math.min(attack.distance, weapon.range);
+        let markerPosition = attack.position;
+        if (attack.distance > 0 && attack.distance !== clampedDistance) {
+          const scale = clampedDistance / attack.distance;
+          markerPosition = {
+            x: player.position.x + (attack.position.x - player.position.x) * scale,
+            y: player.position.y + (attack.position.y - player.position.y) * scale
+          };
+        }
+        const markerDuration = 0.25;
+        hitMarkers.push({
+          position: markerPosition,
+          distance: clampedDistance,
+          timer: markerDuration,
+          duration: markerDuration,
+          kind: attack.kind
+        });
         lastAttackTime = time;
       }
     }
@@ -222,7 +252,15 @@ async function bootstrap() {
       });
     }
 
-    renderer.render(raycaster, player, spriteList, hudState, player.weapons[player.activeWeapon].definition, settings);
+    renderer.render(
+      raycaster,
+      player,
+      spriteList,
+      hudState,
+      player.weapons[player.activeWeapon].definition,
+      hitMarkers,
+      settings
+    );
   });
 
   window.addEventListener('resize', () => renderer.resize(settings.dynamicResolution));

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,5 +1,5 @@
 import { config } from './config';
-import type { PlayerState, Settings, SpriteRenderable, WeaponDefinition } from './types';
+import type { HitMarker, PlayerState, Settings, SpriteRenderable, WeaponDefinition } from './types';
 import { renderHUD, HUDState } from './hud';
 import { Raycaster } from './raycaster';
 
@@ -36,7 +36,15 @@ export class Renderer {
     this.depthBuffer = new Array(this.view.width).fill(0);
   }
 
-  render(raycaster: Raycaster, player: PlayerState, sprites: SpriteRenderable[], hud: HUDState, weapon: WeaponDefinition, settings: Settings) {
+  render(
+    raycaster: Raycaster,
+    player: PlayerState,
+    sprites: SpriteRenderable[],
+    hud: HUDState,
+    weapon: WeaponDefinition,
+    hitMarkers: HitMarker[],
+    settings: Settings
+  ) {
     const ctx = this.viewCtx;
     const width = this.view.width;
     const height = this.view.height;
@@ -131,6 +139,53 @@ export class Renderer {
           );
         }
       }
+    }
+
+    if (hitMarkers.length > 0) {
+      ctx.save();
+      ctx.lineCap = 'round';
+      const invDet = 1.0 / (planeX * dirY - dirX * planeY);
+      for (const marker of hitMarkers) {
+        if (marker.timer <= 0 || marker.duration <= 0) continue;
+        const fade = Math.max(0, Math.min(1, marker.timer / marker.duration));
+        if (fade <= 0) continue;
+
+        const markerX = marker.position.x - posX;
+        const markerY = marker.position.y - posY;
+        const transformX = invDet * (dirY * markerX - dirX * markerY);
+        const transformY = invDet * (-planeY * markerX + planeX * markerY);
+        if (transformY <= 0) continue;
+
+        const screenX = Math.floor((width / 2) * (1 + transformX / transformY));
+        if (screenX < 0 || screenX >= width) continue;
+
+        const bufferIndex = Math.min(width - 1, Math.max(0, screenX));
+        const depth = this.depthBuffer[bufferIndex] ?? Infinity;
+        if (transformY > depth + 0.0001) continue;
+
+        const projectedHeight = Math.abs(Math.floor(height / transformY));
+        const size = Math.max(2, Math.min(12, Math.floor(projectedHeight * 0.1) || 0));
+        const centerY = Math.floor(height / 2);
+
+        ctx.globalAlpha = fade;
+        ctx.strokeStyle = marker.kind === 'enemy' ? '#ff5a5f' : '#f2d16b';
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.moveTo(screenX - size, centerY);
+        ctx.lineTo(screenX + size, centerY);
+        ctx.moveTo(screenX, centerY - size);
+        ctx.lineTo(screenX, centerY + size);
+        ctx.stroke();
+
+        const innerSize = Math.max(1, size * 0.5);
+        ctx.beginPath();
+        ctx.moveTo(screenX - innerSize, centerY - innerSize);
+        ctx.lineTo(screenX + innerSize, centerY + innerSize);
+        ctx.moveTo(screenX - innerSize, centerY + innerSize);
+        ctx.lineTo(screenX + innerSize, centerY - innerSize);
+        ctx.stroke();
+      }
+      ctx.restore();
     }
 
     this.ctx.imageSmoothingEnabled = false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,3 +127,11 @@ export interface HUDMessage {
   text: string;
   timer: number;
 }
+
+export interface HitMarker {
+  position: Vec2;
+  distance: number;
+  timer: number;
+  duration: number;
+  kind: 'enemy' | 'wall';
+}

--- a/src/weapons.js
+++ b/src/weapons.js
@@ -1,5 +1,4 @@
 import { distance, dot, normalize } from './math.js';
-import { applyDamage } from './enemy.js';
 
 export function createWeaponDefinitions(assets) {
   return {
@@ -37,39 +36,61 @@ export function createWeaponDefinitions(assets) {
   };
 }
 
-export function performAttack(def, player, enemies) {
-  let target = null;
-  if (def.id === 'pistol') {
-    let closestDistance = def.range;
-    for (const enemy of enemies) {
-      if (!enemy.alive) continue;
-      const toEnemy = {
-        x: enemy.position.x - player.position.x,
-        y: enemy.position.y - player.position.y
-      };
-      const dist = distance(enemy.position, player.position);
-      if (dist > def.range) continue;
-      const direction = normalize(player.direction);
-      const enemyDir = normalize(toEnemy);
-      const facing = dot(direction, enemyDir);
-      if (facing < 0.85) continue;
-      if (dist < closestDistance) {
-        closestDistance = dist;
-        target = enemy;
-      }
-    }
-  } else {
-    for (const enemy of enemies) {
-      if (!enemy.alive) continue;
-      const dist = distance(enemy.position, player.position);
-      if (dist <= def.range) {
-        target = enemy;
-        break;
-      }
+export function performAttack(def, player, enemies, raycaster) {
+  const origin = player.position;
+  const direction = normalize(player.direction);
+  const wallHit = raycaster.cast(origin, direction);
+  const maxDistance = Math.min(wallHit.distance, def.range);
+
+  let closestEnemy = null;
+  let closestDistance = maxDistance;
+
+  for (const enemy of enemies) {
+    if (!enemy.alive) continue;
+    const toEnemy = {
+      x: enemy.position.x - origin.x,
+      y: enemy.position.y - origin.y
+    };
+    const enemyDistance = distance(enemy.position, origin);
+    if (enemyDistance > def.range) continue;
+
+    const forwardProjection = dot(toEnemy, direction);
+    if (forwardProjection <= 0) continue;
+
+    const lateralSq = enemyDistance * enemyDistance - forwardProjection * forwardProjection;
+    const lateralDistance = lateralSq > 0 ? Math.sqrt(lateralSq) : 0;
+    if (lateralDistance > 0.6) continue;
+
+    if (forwardProjection < closestDistance + 1e-6) {
+      closestEnemy = enemy;
+      closestDistance = Math.min(forwardProjection, maxDistance);
     }
   }
-  if (target) {
-    applyDamage(target, def.damage);
+
+  if (closestEnemy) {
+    const hitDistance = Math.min(closestDistance, def.range);
+    const position = {
+      x: origin.x + direction.x * hitDistance,
+      y: origin.y + direction.y * hitDistance
+    };
+    return {
+      enemy: closestEnemy,
+      kind: 'enemy',
+      position,
+      distance: hitDistance
+    };
   }
-  return target;
+
+  const wallDistance = Math.min(wallHit.distance, def.range);
+  const wallPosition = {
+    x: origin.x + direction.x * wallDistance,
+    y: origin.y + direction.y * wallDistance
+  };
+
+  return {
+    enemy: null,
+    kind: 'wall',
+    position: wallPosition,
+    distance: wallDistance
+  };
 }

--- a/src/weapons.ts
+++ b/src/weapons.ts
@@ -1,6 +1,13 @@
-import type { EnemyInstance, PlayerState, WeaponDefinition, WeaponType } from './types';
+import type { EnemyInstance, PlayerState, Vec2, WeaponDefinition, WeaponType } from './types';
 import { distance, dot, normalize } from './math';
-import { applyDamage } from './enemy';
+import { Raycaster } from './raycaster';
+
+export interface AttackResult {
+  enemy: EnemyInstance | null;
+  kind: 'enemy' | 'wall';
+  position: Vec2;
+  distance: number;
+}
 
 export function createWeaponDefinitions(assets: Record<WeaponType, HTMLCanvasElement>): Record<WeaponType, WeaponDefinition> {
   return {
@@ -38,39 +45,66 @@ export function createWeaponDefinitions(assets: Record<WeaponType, HTMLCanvasEle
   };
 }
 
-export function performAttack(def: WeaponDefinition, player: PlayerState, enemies: EnemyInstance[]): EnemyInstance | null {
-  let target: EnemyInstance | null = null;
-  if (def.id === 'pistol') {
-    let closestDistance = def.range;
-    for (const enemy of enemies) {
-      if (!enemy.alive) continue;
-      const toEnemy = {
-        x: enemy.position.x - player.position.x,
-        y: enemy.position.y - player.position.y
-      };
-      const dist = distance(enemy.position, player.position);
-      if (dist > def.range) continue;
-      const direction = normalize(player.direction);
-      const enemyDir = normalize(toEnemy);
-      const facing = dot(direction, enemyDir);
-      if (facing < 0.85) continue;
-      if (dist < closestDistance) {
-        closestDistance = dist;
-        target = enemy;
-      }
-    }
-  } else {
-    for (const enemy of enemies) {
-      if (!enemy.alive) continue;
-      const dist = distance(enemy.position, player.position);
-      if (dist <= def.range) {
-        target = enemy;
-        break;
-      }
+export function performAttack(
+  def: WeaponDefinition,
+  player: PlayerState,
+  enemies: EnemyInstance[],
+  raycaster: Raycaster
+): AttackResult {
+  const origin = player.position;
+  const direction = normalize(player.direction);
+  const wallHit = raycaster.cast(origin, direction);
+  const maxDistance = Math.min(wallHit.distance, def.range);
+
+  let closestEnemy: EnemyInstance | null = null;
+  let closestDistance = maxDistance;
+
+  for (const enemy of enemies) {
+    if (!enemy.alive) continue;
+    const toEnemy = {
+      x: enemy.position.x - origin.x,
+      y: enemy.position.y - origin.y
+    };
+    const enemyDistance = distance(enemy.position, origin);
+    if (enemyDistance > def.range) continue;
+
+    const forwardProjection = dot(toEnemy, direction);
+    if (forwardProjection <= 0) continue;
+
+    const lateralSq = enemyDistance * enemyDistance - forwardProjection * forwardProjection;
+    const lateralDistance = lateralSq > 0 ? Math.sqrt(lateralSq) : 0;
+    if (lateralDistance > 0.6) continue;
+
+    if (forwardProjection < closestDistance + 1e-6) {
+      closestEnemy = enemy;
+      closestDistance = Math.min(forwardProjection, maxDistance);
     }
   }
-  if (target) {
-    applyDamage(target, def.damage);
+
+  if (closestEnemy) {
+    const hitDistance = Math.min(closestDistance, def.range);
+    const position = {
+      x: origin.x + direction.x * hitDistance,
+      y: origin.y + direction.y * hitDistance
+    };
+    return {
+      enemy: closestEnemy,
+      kind: 'enemy',
+      position,
+      distance: hitDistance
+    };
   }
-  return target;
+
+  const wallDistance = Math.min(wallHit.distance, def.range);
+  const wallPosition = {
+    x: origin.x + direction.x * wallDistance,
+    y: origin.y + direction.y * wallDistance
+  };
+
+  return {
+    enemy: null,
+    kind: 'wall',
+    position: wallPosition,
+    distance: wallDistance
+  };
 }


### PR DESCRIPTION
## Summary
- add a HitMarker type and track hit markers during gameplay
- update attacks to raycast against walls, pick the nearest valid enemy, and report detailed results
- draw fading hit markers in the renderer while applying damage in the main loop

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d82e8d99b08333874ea65f7d16ede9