### PR TITLE
Gate melee hit markers on nearby walls

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -13,6 +13,7 @@ import { applyDamage, createEnemy, updateEnemies } from './enemy.js';
 import { createPickup, tryCollect } from './pickups.js';
 import { UIManager } from './ui.js';
 import { findNearestOpenPosition } from './collisions.js';
+import { normalize } from './math.js';
 
 function injectStyles() {
   const style = document.createElement('style');
@@ -191,14 +192,23 @@ async function bootstrap() {
             y: player.position.y + (attack.position.y - player.position.y) * scale
           };
         }
-        const markerDuration = 0.25;
-        hitMarkers.push({
-          position: markerPosition,
-          distance: clampedDistance,
-          timer: markerDuration,
-          duration: markerDuration,
-          kind: attack.kind
-        });
+        let shouldAddMarker = true;
+        if (!attack.enemy && (weapon.id === 'punch' || weapon.id === 'knife')) {
+          const direction = normalize(player.direction);
+          const meleeWallHit = raycaster.cast(player.position, direction);
+          shouldAddMarker = meleeWallHit.distance <= 1;
+        }
+
+        if (shouldAddMarker) {
+          const markerDuration = 0.25;
+          hitMarkers.push({
+            position: markerPosition,
+            distance: clampedDistance,
+            timer: markerDuration,
+            duration: markerDuration,
+            kind: attack.kind
+          });
+        }
         lastAttackTime = time;
       }
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import { createPickup, tryCollect } from './pickups';
 import type { EnemyInstance, HitMarker, PickupInstance, Settings, SpriteRenderable } from './types';
 import { UIManager } from './ui';
 import { findNearestOpenPosition } from './collisions';
+import { normalize } from './math';
 
 function injectStyles() {
   const style = document.createElement('style');
@@ -192,14 +193,23 @@ async function bootstrap() {
             y: player.position.y + (attack.position.y - player.position.y) * scale
           };
         }
-        const markerDuration = 0.25;
-        hitMarkers.push({
-          position: markerPosition,
-          distance: clampedDistance,
-          timer: markerDuration,
-          duration: markerDuration,
-          kind: attack.kind
-        });
+        let shouldAddMarker = true;
+        if (!attack.enemy && (weapon.id === 'punch' || weapon.id === 'knife')) {
+          const direction = normalize(player.direction);
+          const meleeWallHit = raycaster.cast(player.position, direction);
+          shouldAddMarker = meleeWallHit.distance <= 1;
+        }
+
+        if (shouldAddMarker) {
+          const markerDuration = 0.25;
+          hitMarkers.push({
+            position: markerPosition,
+            distance: clampedDistance,
+            timer: markerDuration,
+            duration: markerDuration,
+            kind: attack.kind
+          });
+        }
         lastAttackTime = time;
       }
     }


### PR DESCRIPTION
## Summary
- require melee hit markers to confirm a nearby wall via a fresh raycast before showing splash feedback
- mirror the melee hit-marker guard in the generated JavaScript to keep the runtime in sync

## Testing
- npx tsc --noEmit *(fails: Cannot find module 'howler')*


------
https://chatgpt.com/codex/tasks/task_e_68d8312b6fe48333bea024dda1d298e5