### PR TITLE
Hide legacy joystick UI

### DIFF
--- a/src/touch.ts
+++ b/src/touch.ts
@@ -7,6 +7,7 @@ interface PointerData {
   startY: number;
   currentX: number;
   currentY: number;
+  element: HTMLElement;
   active: boolean;
 }
 
@@ -14,9 +15,10 @@ const DEADZONE = 0.12;
 
 export class TouchControls {
   private container: HTMLDivElement;
+  private moveOverlay: HTMLDivElement;
+  private lookOverlay: HTMLDivElement;
   private joystick: HTMLDivElement;
   private joystickKnob: HTMLDivElement;
-  private lookPad: HTMLDivElement;
   private rightControls: HTMLDivElement;
   private buttonCluster: HTMLDivElement;
   private fireButton: HTMLButtonElement;
@@ -41,14 +43,16 @@ export class TouchControls {
     this.container.className = 'touch-container';
     this.container.style.cssText = `position:fixed;inset:0;pointer-events:none;font-family:inherit;`;
 
+    this.moveOverlay = document.createElement('div');
+    this.moveOverlay.className = 'touch-move-overlay';
+    this.lookOverlay = document.createElement('div');
+    this.lookOverlay.className = 'touch-look-overlay';
+
     this.joystick = document.createElement('div');
     this.joystick.className = 'touch-joystick';
     this.joystickKnob = document.createElement('div');
     this.joystickKnob.className = 'touch-joystick-knob';
     this.joystick.appendChild(this.joystickKnob);
-
-    this.lookPad = document.createElement('div');
-    this.lookPad.className = 'touch-lookpad';
 
     this.rightControls = document.createElement('div');
     this.rightControls.className = 'touch-right-controls';
@@ -87,6 +91,8 @@ export class TouchControls {
       }
     }
 
+    this.container.appendChild(this.moveOverlay);
+    this.container.appendChild(this.lookOverlay);
     this.container.appendChild(this.joystick);
     this.buttonCluster = document.createElement('div');
     this.buttonCluster.className = 'touch-buttons';
@@ -109,7 +115,6 @@ export class TouchControls {
     this.buttonCluster.appendChild(actionRow);
     this.buttonCluster.appendChild(this.pauseButton);
 
-    this.rightControls.appendChild(this.lookPad);
     this.rightControls.appendChild(this.buttonCluster);
     this.container.appendChild(this.rightControls);
 
@@ -151,8 +156,8 @@ export class TouchControls {
 
   private attachPointerListeners() {
     const pointerOptions = { passive: false } as AddEventListenerOptions;
-    this.joystick.addEventListener('pointerdown', (e) => this.beginMove(e), pointerOptions);
-    this.lookPad.addEventListener('pointerdown', (e) => this.beginLook(e), pointerOptions);
+    this.moveOverlay.addEventListener('pointerdown', (e) => this.onOverlayPointerDown(e), pointerOptions);
+    this.lookOverlay.addEventListener('pointerdown', (e) => this.onOverlayPointerDown(e), pointerOptions);
     window.addEventListener('pointermove', (e) => this.onPointerMove(e), pointerOptions);
     window.addEventListener('pointerup', (e) => this.endPointer(e));
     window.addEventListener('pointercancel', (e) => this.endPointer(e));
@@ -177,56 +182,112 @@ export class TouchControls {
     });
   }
 
-  private beginMove(e: PointerEvent) {
+  private onOverlayPointerDown(e: PointerEvent) {
+    if (!this.visible) return;
+    if (this.shouldIgnorePointerTarget(e.target)) return;
+    e.preventDefault();
+    const overlay = e.currentTarget as HTMLElement;
+    const isMove = this.isMoveSide(e.clientX);
+    if (isMove) {
+      if (this.movePointer) return;
+      this.beginMove(e, overlay);
+    } else {
+      if (this.lookPointer) return;
+      this.beginLook(e, overlay);
+    }
+  }
+
+  private shouldIgnorePointerTarget(target: EventTarget | null) {
+    if (!(target instanceof HTMLElement)) return false;
+    if (target === this.fireButton || target === this.interactButton) {
+      return true;
+    }
+    if (this.buttonCluster.contains(target)) {
+      return true;
+    }
+    return false;
+  }
+
+  private isMoveSide(clientX: number) {
+    const halfWidth = window.innerWidth / 2;
+    if (this.settings.leftHanded) {
+      return clientX > halfWidth;
+    }
+    return clientX <= halfWidth;
+  }
+
+  private getPointerForEvent(e: PointerEvent): { pointer: PointerData; type: 'move' | 'look' } | null {
+    const preferMove = this.isMoveSide(e.clientX);
+    const primary = preferMove ? this.movePointer : this.lookPointer;
+    const secondary = preferMove ? this.lookPointer : this.movePointer;
+    if (primary && primary.id === e.pointerId) {
+      return { pointer: primary, type: preferMove ? 'move' : 'look' };
+    }
+    if (secondary && secondary.id === e.pointerId) {
+      return { pointer: secondary, type: preferMove ? 'look' : 'move' };
+    }
+    return null;
+  }
+
+  private beginMove(e: PointerEvent, element: HTMLElement) {
     if (this.movePointer) return;
+    if (!this.isMoveSide(e.clientX)) return;
     this.movePointer = {
       id: e.pointerId,
       startX: e.clientX,
       startY: e.clientY,
       currentX: e.clientX,
       currentY: e.clientY,
+      element,
       active: true
     };
     this.updateJoystickVisual();
-    this.joystick.setPointerCapture(e.pointerId);
+    element.setPointerCapture(e.pointerId);
   }
 
-  private beginLook(e: PointerEvent) {
+  private beginLook(e: PointerEvent, element: HTMLElement) {
     if (this.lookPointer) return;
+    if (this.isMoveSide(e.clientX)) return;
     this.lookPointer = {
       id: e.pointerId,
       startX: e.clientX,
       startY: e.clientY,
       currentX: e.clientX,
       currentY: e.clientY,
+      element,
       active: true
     };
-    this.lookPad.setPointerCapture(e.pointerId);
+    element.setPointerCapture(e.pointerId);
   }
 
   private onPointerMove(e: PointerEvent) {
-    if (this.movePointer && this.movePointer.id === e.pointerId) {
-      this.movePointer.currentX = e.clientX;
-      this.movePointer.currentY = e.clientY;
+    if (this.shouldIgnorePointerTarget(e.target)) return;
+    const match = this.getPointerForEvent(e);
+    if (!match) return;
+    if (match.type === 'move') {
+      match.pointer.currentX = e.clientX;
+      match.pointer.currentY = e.clientY;
       this.updateJoystickVisual();
-    }
-    if (this.lookPointer && this.lookPointer.id === e.pointerId) {
-      const dx = e.clientX - this.lookPointer.currentX;
-      this.lookPointer.currentX = e.clientX;
-      this.lookPointer.currentY = e.clientY;
+    } else {
+      const dx = e.clientX - match.pointer.currentX;
+      match.pointer.currentX = e.clientX;
+      match.pointer.currentY = e.clientY;
       this.lookDelta += dx;
     }
   }
 
   private endPointer(e: PointerEvent) {
-    if (this.movePointer && this.movePointer.id === e.pointerId) {
-      this.joystick.releasePointerCapture(e.pointerId);
-      this.movePointer = null;
-      this.updateJoystickVisual();
-    }
-    if (this.lookPointer && this.lookPointer.id === e.pointerId) {
-      this.lookPad.releasePointerCapture(e.pointerId);
-      this.lookPointer = null;
+    if (!this.shouldIgnorePointerTarget(e.target)) {
+      const match = this.getPointerForEvent(e);
+      if (match) {
+        match.pointer.element.releasePointerCapture(e.pointerId);
+        if (match.type === 'move') {
+          this.movePointer = null;
+          this.updateJoystickVisual();
+        } else {
+          this.lookPointer = null;
+        }
+      }
     }
     if (this.fireHeld && e.target === this.fireButton) {
       this.fireHeld = false;
@@ -252,17 +313,16 @@ export class TouchControls {
 
   private applyStyles() {
     const baseOpacity = this.settings.uiOpacity;
-    const joystickSide = this.settings.leftHanded ? 'right' : 'left';
-    const joystickOppositeSide = this.settings.leftHanded ? 'left' : 'right';
-    this.joystick.style.cssText = `position:absolute;bottom:20%;${joystickSide}:6%;${joystickOppositeSide}:auto;pointer-events:auto;border-radius:50%;background:rgba(40,40,60,${baseOpacity});backdrop-filter:blur(6px);touch-action:none;display:flex;align-items:center;justify-content:center;`;
-    this.joystickKnob.style.cssText =
-      'position:absolute;top:50%;left:50%;transform:translate(-50%, -50%);background:rgba(255,255,255,0.7);border-radius:50%;transition:background 0.1s;';
-    const lookPadSize = this.settings.joystickSize * 1.1;
-    this.lookPad.style.cssText = `width:${lookPadSize}px;height:${lookPadSize}px;border-radius:18px;background:rgba(40,40,60,${baseOpacity});pointer-events:auto;touch-action:none;`;
+    this.joystick.style.cssText = 'display:none;pointer-events:none;';
+    this.joystickKnob.style.cssText = 'display:none;';
+    this.moveOverlay.style.cssText =
+      'position:absolute;top:0;bottom:0;left:0;width:50%;background:transparent;pointer-events:auto;touch-action:none;z-index:1;';
+    this.lookOverlay.style.cssText =
+      'position:absolute;top:0;bottom:0;right:0;width:50%;background:transparent;pointer-events:auto;touch-action:none;z-index:1;';
     const controlsSide = this.settings.leftHanded ? 'left' : 'right';
     const controlsOppositeSide = this.settings.leftHanded ? 'right' : 'left';
     const alignItems = this.settings.leftHanded ? 'flex-start' : 'flex-end';
-    this.rightControls.style.cssText = `position:absolute;bottom:18%;${controlsSide}:4%;${controlsOppositeSide}:auto;display:flex;flex-direction:column;align-items:${alignItems};gap:18px;pointer-events:auto;`;
+    this.rightControls.style.cssText = `position:absolute;bottom:18%;${controlsSide}:4%;${controlsOppositeSide}:auto;display:flex;flex-direction:column;align-items:${alignItems};gap:18px;pointer-events:auto;z-index:5;`;
     this.buttonCluster.style.alignItems = alignItems;
     this.fireButton.style.background = `rgba(255,120,80,${baseOpacity + 0.2})`;
     this.interactButton.style.background = `rgba(120,200,255,${baseOpacity + 0.2})`;


### PR DESCRIPTION
## Summary
- add transparent move/look overlays that span the viewport halves and decide move vs. look based on pointer position while ignoring button presses
- update pointer tracking to capture and release through the overlays without blocking existing fire/interact/pause/weapon buttons
- refresh touch control styling so overlays sit behind buttons and the joystick visual remains informative without handling input
- hide the legacy joystick visual so only the half-screen overlays handle touch input

## Testing
- npm run build *(fails: Missing script "build")*

------
https://chatgpt.com/codex/tasks/task_e_68d9a377e5c08333a2496fcb274a24ab