### PR TITLE
Refine weapon sprite spacing from crosshair

### DIFF
--- a/src/hud.ts
+++ b/src/hud.ts
@@ -112,13 +112,39 @@ export function renderHUD(
   }
 
   if (weapon.sprite) {
-    const weaponWidth = canvas.width * 0.35;
-    const aspect = weapon.sprite.height / weapon.sprite.width;
-    const weaponHeight = weaponWidth * aspect;
-    const weaponX = canvas.width / 2 - weaponWidth / 2;
-    const weaponY = canvas.height - hudHeight - weaponHeight + 20;
-    ctx.imageSmoothingEnabled = false;
-    ctx.drawImage(weapon.sprite, weaponX, weaponY, weaponWidth, weaponHeight);
+    const hudTop = canvas.height - hudHeight;
+    const crosshairExtent = 16;
+    const verticalPadding = 24;
+    const bottomPadding = 12;
+    const crosshairBottom = canvas.height / 2 + crosshairExtent;
+    const minWeaponTop = crosshairBottom + verticalPadding;
+    const maxWeaponBottom = hudTop - bottomPadding;
+    const availableHeight = Math.max(0, maxWeaponBottom - minWeaponTop);
+
+    if (availableHeight > 0) {
+      const aspect = weapon.sprite.height / weapon.sprite.width;
+      const maxWeaponWidth = canvas.width * 0.6;
+      let weaponHeight = availableHeight;
+      let weaponWidth = weaponHeight / aspect;
+
+      if (weaponWidth > maxWeaponWidth) {
+        weaponWidth = maxWeaponWidth;
+        weaponHeight = weaponWidth * aspect;
+      }
+
+      if (weaponHeight > availableHeight) {
+        weaponHeight = availableHeight;
+        weaponWidth = weaponHeight / aspect;
+      }
+
+      const weaponX = (canvas.width - weaponWidth) / 2;
+      let weaponY = maxWeaponBottom - weaponHeight;
+      if (weaponY < minWeaponTop) {
+        weaponY = minWeaponTop;
+      }
+      ctx.imageSmoothingEnabled = false;
+      ctx.drawImage(weapon.sprite, weaponX, weaponY, weaponWidth, weaponHeight);
+    }
   }
 
   ctx.save();


### PR DESCRIPTION
## Summary
- bound the weapon sprite height to the gap between the crosshair and HUD with explicit top/bottom margins
- clamp the sprite width to 60% of the canvas and recalculate height to preserve aspect ratio
- keep the sprite centered and ensure its top never intrudes on the crosshair padding

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9c9c23ca8833384b4692ebc8a8122