### PR TITLE
Clamp weapon sprite below crosshair

### DIFF
--- a/src/hud.ts
+++ b/src/hud.ts
@@ -112,11 +112,22 @@ export function renderHUD(
   }
 
   if (weapon.sprite) {
-    const weaponWidth = canvas.width * 0.35;
+    const hudTop = canvas.height - hudHeight;
+    const centerY = canvas.height / 2;
+    const safetyMargin = 24;
+    const maxWeaponHeight = Math.max(0, hudTop - centerY - safetyMargin);
+
+    let weaponWidth = canvas.width * 0.35;
     const aspect = weapon.sprite.height / weapon.sprite.width;
-    const weaponHeight = weaponWidth * aspect;
+    let weaponHeight = weaponWidth * aspect;
+
+    if (weaponHeight > maxWeaponHeight && maxWeaponHeight > 0) {
+      weaponHeight = maxWeaponHeight;
+      weaponWidth = weaponHeight / aspect;
+    }
+
     const weaponX = canvas.width / 2 - weaponWidth / 2;
-    const weaponY = canvas.height - hudHeight - weaponHeight + 20;
+    const weaponY = Math.max(centerY + safetyMargin, hudTop - weaponHeight);
     ctx.imageSmoothingEnabled = false;
     ctx.drawImage(weapon.sprite, weaponX, weaponY, weaponWidth, weaponHeight);
   }


### PR DESCRIPTION
## Summary
- cap the weapon sprite height using the distance between the HUD and screen center with a safety margin
- resize the weapon sprite proportionally and position it so it always starts below the crosshair

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9d51a12248333bd2701776fedeb8e