### PR TITLE
Clamp HUD weapon sprite consistently across builds

### DIFF
--- a/src/hud.js
+++ b/src/hud.js
@@ -84,11 +84,23 @@ export function renderHUD(ctx, canvas, player, weapon, hud, settings, level, spr
   }
 
   if (weapon.sprite) {
-    const weaponWidth = canvas.width * 0.35;
+    const hudTop = canvas.height - hudHeight;
+    const centerY = canvas.height / 2;
+    const safetyMargin = 24;
+    const maxWeaponHeight = Math.max(0, hudTop - (centerY + safetyMargin));
+
+    let weaponWidth = canvas.width * 0.35;
     const aspect = weapon.sprite.height / weapon.sprite.width;
-    const weaponHeight = weaponWidth * aspect;
+    let weaponHeight = weaponWidth * aspect;
+
+    if (maxWeaponHeight > 0 && weaponHeight > maxWeaponHeight) {
+      const scale = maxWeaponHeight / weaponHeight;
+      weaponHeight = maxWeaponHeight;
+      weaponWidth *= scale;
+    }
+
     const weaponX = canvas.width / 2 - weaponWidth / 2;
-    const weaponY = canvas.height - hudHeight - weaponHeight + 20;
+    const weaponY = Math.max(centerY + safetyMargin, hudTop - weaponHeight);
     ctx.imageSmoothingEnabled = false;
     ctx.drawImage(weapon.sprite, weaponX, weaponY, weaponWidth, weaponHeight);
   }

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -112,11 +112,23 @@ export function renderHUD(
   }
 
   if (weapon.sprite) {
-    const weaponWidth = canvas.width * 0.35;
+    const hudTop = canvas.height - hudHeight;
+    const centerY = canvas.height / 2;
+    const safetyMargin = 24;
+    const maxWeaponHeight = Math.max(0, hudTop - (centerY + safetyMargin));
+
+    let weaponWidth = canvas.width * 0.35;
     const aspect = weapon.sprite.height / weapon.sprite.width;
-    const weaponHeight = weaponWidth * aspect;
+    let weaponHeight = weaponWidth * aspect;
+
+    if (maxWeaponHeight > 0 && weaponHeight > maxWeaponHeight) {
+      const scale = maxWeaponHeight / weaponHeight;
+      weaponHeight = maxWeaponHeight;
+      weaponWidth *= scale;
+    }
+
     const weaponX = canvas.width / 2 - weaponWidth / 2;
-    const weaponY = canvas.height - hudHeight - weaponHeight + 20;
+    const weaponY = Math.max(centerY + safetyMargin, hudTop - weaponHeight);
     ctx.imageSmoothingEnabled = false;
     ctx.drawImage(weapon.sprite, weaponX, weaponY, weaponWidth, weaponHeight);
   }


### PR DESCRIPTION
## Summary
- apply the same weapon clamping logic to the JavaScript HUD renderer that the runtime uses
- tighten the TypeScript implementation so the sprite width scales proportionally when capped by the safety height

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'howler')*

------
https://chatgpt.com/codex/tasks/task_e_68d9d51a12248333bd2701776fedeb8e