### PR TITLE
Fix touch strafe direction in runtime JS

### DIFF
--- a/src/touch.js
+++ b/src/touch.js
@@ -296,7 +296,7 @@ export class TouchControls {
     }
     const move = this.getMoveVector();
     const forward = -move.y;
-    const strafe = -move.x;
+    const strafe = move.x;
     const turning = clamp(this.lookDelta * 0.003, -0.45, 0.45);
     const fire = this.fireHeld;
     const interact = this.interactHeld;

--- a/src/touch.ts
+++ b/src/touch.ts
@@ -304,7 +304,7 @@ export class TouchControls {
     }
     const move = this.getMoveVector();
     const forward = -move.y;
-    const strafe = -move.x;
+    const strafe = move.x;
     const turning = clamp(this.lookDelta * 0.003, -0.45, 0.45);
     const fire = this.fireHeld;
     const interact = this.interactHeld;


### PR DESCRIPTION
## Summary
- align the touch controller strafe axis in the JavaScript runtime file so dragging right moves right

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f98f505fc88333bbe8d8188a7714f5